### PR TITLE
feat: scaffold immersive 3d mode overlays

### DIFF
--- a/nexspace-frontend/package.json
+++ b/nexspace-frontend/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest",
+    "test:run": "vitest run"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.1",
@@ -39,6 +41,7 @@
     "tailwindcss": "^3.4.17",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.0",
-    "vite": "^7.1.0"
+    "vite": "^7.1.0",
+    "vitest": "^2.1.4"
   }
 }

--- a/nexspace-frontend/src/components/MeetingPanel.tsx
+++ b/nexspace-frontend/src/components/MeetingPanel.tsx
@@ -7,6 +7,7 @@ import MeetingControls from "./MeetingControls";
 import MeetingGrid from "./MeetingGrid";
 import TopWidget from "./TopWidget";
 import ChatPanel from "./ChatPanel";
+import ThreeDExperience from "../features/threeDMode/components/ThreeDExperience";
 import { useMeetingStore } from "../stores/meetingStore";
 import { useUIStore } from "../stores/uiStore";
 import { useMediaQuery } from "../hooks/useMedia";
@@ -155,9 +156,7 @@ const MeetingPanel: React.FC = () => {
 
           {/* Stage: Grid or 3D */}
           {viewMode === '3d' ? (
-
-            <div className="grid place-items-center h-full text-white">3D View Coming Soon!</div>
-
+            <ThreeDExperience />
           ) : (
             <MeetingGrid pageSize={24} bottomSafeAreaPx={isMobile ? 96 : 120} topSafeAreaPx={showTop ? 96 : 16} />
           )}

--- a/nexspace-frontend/src/constants/themeTokens.ts
+++ b/nexspace-frontend/src/constants/themeTokens.ts
@@ -1,0 +1,55 @@
+export type ThemeMode = 'dark' | 'light';
+
+export type ThemeTokens = {
+  background: string;
+  surface: string;
+  surfaceAlt: string;
+  surfaceAlpha: string;
+  textPrimary: string;
+  textSecondary: string;
+  textMuted: string;
+  accent: string;
+  accentSoft: string;
+  borderSoft: string;
+  borderStrong: string;
+  gridLine: string;
+  success: string;
+  warning: string;
+};
+
+export const themeTokens: Record<ThemeMode, ThemeTokens> = {
+  dark: {
+    background: '#0B0C10',
+    surface: 'rgba(23, 25, 35, 0.88)',
+    surfaceAlt: '#141622',
+    surfaceAlpha: 'rgba(18, 20, 29, 0.72)',
+    textPrimary: '#EEF1F9',
+    textSecondary: 'rgba(211, 218, 239, 0.72)',
+    textMuted: 'rgba(211, 218, 239, 0.38)',
+    accent: '#68D8C2',
+    accentSoft: 'rgba(104, 216, 194, 0.4)',
+    borderSoft: 'rgba(122, 130, 160, 0.24)',
+    borderStrong: 'rgba(122, 130, 160, 0.45)',
+    gridLine: 'rgba(255, 255, 255, 0.06)',
+    success: '#5BE49B',
+    warning: '#FFB84D',
+  },
+  light: {
+    background: '#F4F6FB',
+    surface: 'rgba(255, 255, 255, 0.92)',
+    surfaceAlt: '#FFFFFF',
+    surfaceAlpha: 'rgba(255, 255, 255, 0.78)',
+    textPrimary: '#1F2433',
+    textSecondary: 'rgba(31, 36, 51, 0.72)',
+    textMuted: 'rgba(31, 36, 51, 0.42)',
+    accent: '#2B70FF',
+    accentSoft: 'rgba(43, 112, 255, 0.18)',
+    borderSoft: 'rgba(36, 53, 102, 0.16)',
+    borderStrong: 'rgba(36, 53, 102, 0.32)',
+    gridLine: 'rgba(11, 12, 16, 0.05)',
+    success: '#2EAD68',
+    warning: '#F28C28',
+  },
+};
+
+export const getThemeTokens = (mode: ThemeMode): ThemeTokens => themeTokens[mode];

--- a/nexspace-frontend/src/features/threeDMode/README.md
+++ b/nexspace-frontend/src/features/threeDMode/README.md
@@ -22,10 +22,13 @@ It now renders the live campus scene plus supporting UI chrome:
 
 - A performant Three.js scene with baked ambient lighting, room floor meshes, labels, and avatar
   capsules that gently bob to signal presence.
-- Deterministic room-aware avatar layout so occupants distribute evenly across each zone.
+- Deterministic room-aware avatar layout for remote peers plus smooth WASD controls for the local
+  user with collision bounds that keep everyone on campus.
 - A minimap with per-room occupancy counts.
 - Join-nudge surface that deduplicates entries with a cooldown.
 - Quality selector with Low/Medium/High presets that map to renderer fidelity and shadows.
+- Live spatial audio routing tied to room boundaries and proximity falloff so conversations fade as
+  people move away or enter other rooms.
 
 ## Persistence & Settings
 
@@ -36,10 +39,10 @@ It now renders the live campus scene plus supporting UI chrome:
 
 ## Next Steps
 
-1. Connect room boundaries to spatial audio attenuation & voice isolation rules.
-2. Layer in navigation controls (WASD, click-to-move) and proximity-based falloff for avatars.
-3. Wire the join-nudge actions (wave, invite, DM) into the communication stack.
-4. Extend tests to cover proximity calculations once movement updates land.
+1. Wire the join-nudge actions (wave, invite, DM) into the communication stack.
+2. Add click-to-move navigation, waypoint cues, and on-floor wayfinding arrows.
+3. Model interactive room objects (whiteboards, seating, game tables) and connect them to the store.
+4. Integrate room media surfaces with screen share, spotlight mode, and embedded slides/video.
 
 ## Development Notes
 

--- a/nexspace-frontend/src/features/threeDMode/README.md
+++ b/nexspace-frontend/src/features/threeDMode/README.md
@@ -1,13 +1,13 @@
 # 3D Mode Feature Scaffold
 
-This folder contains the initial scaffolding for the immersive 3D workspace mode. The goal of
-this first increment is to provide the structural building blocks that subsequent milestones can
-extend with realtime rendering, spatial audio, and rich interactions.
+This folder now contains the live 3D campus experience for the immersive workspace mode. The
+initial scaffolding has been extended with a Three.js scene, spatial overlays, and data-driven
+layouts that future milestones can wire into realtime audio/video, huddles, and moderation flows.
 
 ## Structure
 
 - `components/` – UI overlays that sit on top of the 3D canvas such as the minimap, quality
-  controls, and join-nudge prompts.
+  controls, join-nudge prompts, and the `ThreeDScene` renderer.
 - `config/` – Room & zone definitions with audio envelopes and signage copy. These are data-driven
   so that we can add, remove, or tweak rooms without touching render logic.
 - `hooks/` – React hooks that sync LiveKit meeting data into the 3D store. The initial
@@ -18,14 +18,14 @@ extend with realtime rendering, spatial audio, and rich interactions.
 ## Usage
 
 The `ThreeDExperience` component is wired into `MeetingPanel` when the view mode is set to `3d`.
-It currently renders a styled placeholder card while exposing functional UI chrome:
+It now renders the live campus scene plus supporting UI chrome:
 
-- Minimap with per-room occupancy counts.
+- A performant Three.js scene with baked ambient lighting, room floor meshes, labels, and avatar
+  capsules that gently bob to signal presence.
+- Deterministic room-aware avatar layout so occupants distribute evenly across each zone.
+- A minimap with per-room occupancy counts.
 - Join-nudge surface that deduplicates entries with a cooldown.
-- Quality selector with Low/Medium/High presets.
-
-These pieces are intentionally lightweight so they can stay mounted when we integrate the Three.js
-scene without causing layout thrash.
+- Quality selector with Low/Medium/High presets that map to renderer fidelity and shadows.
 
 ## Persistence & Settings
 
@@ -36,8 +36,8 @@ scene without causing layout thrash.
 
 ## Next Steps
 
-1. Embed the actual Three.js scene and connect room boundaries to spatial audio attenuation.
-2. Replace the fallback room assignment in `useThreeDAvatarSync` with metadata-driven placement.
+1. Connect room boundaries to spatial audio attenuation & voice isolation rules.
+2. Layer in navigation controls (WASD, click-to-move) and proximity-based falloff for avatars.
 3. Wire the join-nudge actions (wave, invite, DM) into the communication stack.
 4. Extend tests to cover proximity calculations once movement updates land.
 

--- a/nexspace-frontend/src/features/threeDMode/README.md
+++ b/nexspace-frontend/src/features/threeDMode/README.md
@@ -1,0 +1,49 @@
+# 3D Mode Feature Scaffold
+
+This folder contains the initial scaffolding for the immersive 3D workspace mode. The goal of
+this first increment is to provide the structural building blocks that subsequent milestones can
+extend with realtime rendering, spatial audio, and rich interactions.
+
+## Structure
+
+- `components/` – UI overlays that sit on top of the 3D canvas such as the minimap, quality
+  controls, and join-nudge prompts.
+- `config/` – Room & zone definitions with audio envelopes and signage copy. These are data-driven
+  so that we can add, remove, or tweak rooms without touching render logic.
+- `hooks/` – React hooks that sync LiveKit meeting data into the 3D store. The initial
+  `useThreeDAvatarSync` keeps avatar presence in lockstep with the meeting store.
+- `store/` – A Zustand slice that tracks avatar state, room occupancy, quality settings, and the
+  join-nudge queue.
+
+## Usage
+
+The `ThreeDExperience` component is wired into `MeetingPanel` when the view mode is set to `3d`.
+It currently renders a styled placeholder card while exposing functional UI chrome:
+
+- Minimap with per-room occupancy counts.
+- Join-nudge surface that deduplicates entries with a cooldown.
+- Quality selector with Low/Medium/High presets.
+
+These pieces are intentionally lightweight so they can stay mounted when we integrate the Three.js
+scene without causing layout thrash.
+
+## Persistence & Settings
+
+- View mode persistence now lives in the meeting store (`viewMode` reads & writes localStorage).
+- Theme tokens (`src/constants/themeTokens.ts`) centralize dark/light colors for overlays.
+- Quality level lives in the 3D store and is intended to map to renderer fidelity once the scene is
+  online.
+
+## Next Steps
+
+1. Embed the actual Three.js scene and connect room boundaries to spatial audio attenuation.
+2. Replace the fallback room assignment in `useThreeDAvatarSync` with metadata-driven placement.
+3. Wire the join-nudge actions (wave, invite, DM) into the communication stack.
+4. Extend tests to cover proximity calculations once movement updates land.
+
+## Development Notes
+
+- Tests are colocated under `store/__tests__` and run with `npm run test` inside `nexspace-frontend`.
+- Room configuration is exported to support future administrative panels.
+- The store intentionally exposes `markWaypoint` and `quality` even though the rendering layer is
+  not yet consuming them; they will become critical as navigation & perf controls come online.

--- a/nexspace-frontend/src/features/threeDMode/README.md
+++ b/nexspace-frontend/src/features/threeDMode/README.md
@@ -24,11 +24,14 @@ It now renders the live campus scene plus supporting UI chrome:
   capsules that gently bob to signal presence.
 - Deterministic room-aware avatar layout for remote peers plus smooth WASD controls for the local
   user with collision bounds that keep everyone on campus.
-- A minimap with per-room occupancy counts.
+- An interactive minimap with per-room occupancy counts, click-to-waypoint navigation, and
+  Alt-click clearing so teammates can plot paths without breaking flow.
 - Join-nudge surface that deduplicates entries with a cooldown.
 - Quality selector with Low/Medium/High presets that map to renderer fidelity and shadows.
 - Live spatial audio routing tied to room boundaries and proximity falloff so conversations fade as
   people move away or enter other rooms.
+- Dynamic floor cues and in-scene waypoint markers that guide the local avatar toward selected
+  destinations while rendering shared guidance for remote teammates.
 
 ## Persistence & Settings
 
@@ -40,9 +43,9 @@ It now renders the live campus scene plus supporting UI chrome:
 ## Next Steps
 
 1. Wire the join-nudge actions (wave, invite, DM) into the communication stack.
-2. Add click-to-move navigation, waypoint cues, and on-floor wayfinding arrows.
-3. Model interactive room objects (whiteboards, seating, game tables) and connect them to the store.
-4. Integrate room media surfaces with screen share, spotlight mode, and embedded slides/video.
+2. Model interactive room objects (whiteboards, seating, game tables) and connect them to the store.
+3. Integrate room media surfaces with screen share, spotlight mode, and embedded slides/video.
+4. Layer in moderation controls (locks, invite-only huddles) and scheduling reminders tied to rooms.
 
 ## Development Notes
 

--- a/nexspace-frontend/src/features/threeDMode/README.md
+++ b/nexspace-frontend/src/features/threeDMode/README.md
@@ -37,6 +37,9 @@ It now renders the live campus scene plus supporting UI chrome:
   destinations while rendering shared guidance for remote teammates.
 - Distinct room decor for each zone (desks in the open area, lounge seating, conference tables,
   event stage, etc.) to reinforce sense of place without sacrificing performance.
+- Camera controls that match modern 3D spaces: left-drag orbits around your avatar, Shift/right
+  drag pans the camera, the mouse wheel zooms, and first-person mode reuses pointer look with
+  keyboard strafing.
 
 ## Persistence & Settings
 

--- a/nexspace-frontend/src/features/threeDMode/README.md
+++ b/nexspace-frontend/src/features/threeDMode/README.md
@@ -20,18 +20,23 @@ layouts that future milestones can wire into realtime audio/video, huddles, and 
 The `ThreeDExperience` component is wired into `MeetingPanel` when the view mode is set to `3d`.
 It now renders the live campus scene plus supporting UI chrome:
 
-- A performant Three.js scene with baked ambient lighting, room floor meshes, labels, and avatar
-  capsules that gently bob to signal presence.
+- A performant Three.js scene with baked ambient lighting, themed room builds, and avatar capsules
+  that gently bob to signal presence.
 - Deterministic room-aware avatar layout for remote peers plus smooth WASD controls for the local
   user with collision bounds that keep everyone on campus.
 - An interactive minimap with per-room occupancy counts, click-to-waypoint navigation, and
   Alt-click clearing so teammates can plot paths without breaking flow.
-- Join-nudge surface that deduplicates entries with a cooldown.
+- A collapsible control dock that houses room status, the minimap, quality presets, and the new
+  first-person/third-person view toggle.
+- Join-nudge surface that deduplicates entries with a cooldown and now triggers wave, huddle, and
+  DM actions via the meeting store.
 - Quality selector with Low/Medium/High presets that map to renderer fidelity and shadows.
 - Live spatial audio routing tied to room boundaries and proximity falloff so conversations fade as
   people move away or enter other rooms.
 - Dynamic floor cues and in-scene waypoint markers that guide the local avatar toward selected
   destinations while rendering shared guidance for remote teammates.
+- Distinct room decor for each zone (desks in the open area, lounge seating, conference tables,
+  event stage, etc.) to reinforce sense of place without sacrificing performance.
 
 ## Persistence & Settings
 
@@ -42,10 +47,9 @@ It now renders the live campus scene plus supporting UI chrome:
 
 ## Next Steps
 
-1. Wire the join-nudge actions (wave, invite, DM) into the communication stack.
-2. Model interactive room objects (whiteboards, seating, game tables) and connect them to the store.
-3. Integrate room media surfaces with screen share, spotlight mode, and embedded slides/video.
-4. Layer in moderation controls (locks, invite-only huddles) and scheduling reminders tied to rooms.
+1. Model interactive room objects (whiteboards, seating, game tables) and connect them to the store.
+2. Integrate room media surfaces with screen share, spotlight mode, and embedded slides/video.
+3. Layer in moderation controls (locks, invite-only huddles) and scheduling reminders tied to rooms.
 
 ## Development Notes
 

--- a/nexspace-frontend/src/features/threeDMode/__tests__/spatial.test.ts
+++ b/nexspace-frontend/src/features/threeDMode/__tests__/spatial.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { clampToCampusBounds, pointInCircle, pointInRect, resolveRoomForPosition } from '../utils/spatial';
+import {
+  clampToCampusBounds,
+  computeCampusBounds,
+  pointInCircle,
+  pointInRect,
+  resolveRoomForPosition,
+} from '../utils/spatial';
 import { defaultRooms } from '../config/rooms';
 
 const fallbackRoomId = defaultRooms[0]?.id ?? 'open-work-area';
@@ -36,5 +42,19 @@ describe('spatial utils', () => {
     const clamped = clampToCampusBounds({ x: 999, y: -999 }, defaultRooms);
     expect(clamped.x).toBeLessThan(40);
     expect(clamped.y).toBeGreaterThan(-40);
+  });
+
+  it('computes campus bounds extents', () => {
+    const bounds = computeCampusBounds(defaultRooms);
+    expect(bounds).not.toBeNull();
+    if (!bounds) return;
+    expect(bounds.minX).toBeLessThan(bounds.maxX);
+    expect(bounds.width).toBeCloseTo(bounds.maxX - bounds.minX);
+    expect(bounds.height).toBeCloseTo(bounds.maxY - bounds.minY);
+  });
+
+  it('returns null bounds when rooms are empty', () => {
+    const bounds = computeCampusBounds([]);
+    expect(bounds).toBeNull();
   });
 });

--- a/nexspace-frontend/src/features/threeDMode/__tests__/spatial.test.ts
+++ b/nexspace-frontend/src/features/threeDMode/__tests__/spatial.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { clampToCampusBounds, pointInCircle, pointInRect, resolveRoomForPosition } from '../utils/spatial';
+import { defaultRooms } from '../config/rooms';
+
+const fallbackRoomId = defaultRooms[0]?.id ?? 'open-work-area';
+
+describe('spatial utils', () => {
+  it('checks rectangles with rotation', () => {
+    const inside = pointInRect({ x: 1, y: 1 }, [1, 1], [4, 2]);
+    expect(inside).toBe(true);
+
+    const outside = pointInRect({ x: 5, y: 1 }, [1, 1], [4, 2]);
+    expect(outside).toBe(false);
+
+    const rotatedInside = pointInRect({ x: 2, y: 2 }, [2, 2], [4, 2], Math.PI / 4);
+    expect(rotatedInside).toBe(true);
+  });
+
+  it('checks circles', () => {
+    expect(pointInCircle({ x: 0, y: 0 }, [0, 0], 3)).toBe(true);
+    expect(pointInCircle({ x: 4, y: 0 }, [0, 0], 3)).toBe(false);
+  });
+
+  it('resolves room for given position', () => {
+    const openArea = resolveRoomForPosition({ x: 0, y: 0 }, defaultRooms, fallbackRoomId);
+    expect(openArea).toBe('open-work-area');
+
+    const lounge = resolveRoomForPosition({ x: 6, y: -12 }, defaultRooms, fallbackRoomId);
+    expect(lounge).toBe('lounge-zone');
+
+    const fallback = resolveRoomForPosition({ x: 100, y: 100 }, defaultRooms, fallbackRoomId);
+    expect(fallback).toBe(fallbackRoomId);
+  });
+
+  it('clamps positions to campus bounds with padding', () => {
+    const clamped = clampToCampusBounds({ x: 999, y: -999 }, defaultRooms);
+    expect(clamped.x).toBeLessThan(40);
+    expect(clamped.y).toBeGreaterThan(-40);
+  });
+});

--- a/nexspace-frontend/src/features/threeDMode/__tests__/threeDStore.avatars.test.ts
+++ b/nexspace-frontend/src/features/threeDMode/__tests__/threeDStore.avatars.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useThreeDStore } from '../store/threeDStore';
+import { defaultRooms } from '../config/rooms';
+
+const openWork = defaultRooms[0];
+
+describe('threeDStore avatar updates', () => {
+  beforeEach(() => {
+    useThreeDStore.setState({
+      rooms: defaultRooms,
+      avatars: {},
+      localAvatarId: null,
+      joinNudges: [],
+      lastNudgeByAvatar: {},
+      minimapWaypoints: {},
+    });
+  });
+
+  it('avoids unnecessary avatar mutations when data is unchanged', () => {
+    if (!openWork) throw new Error('expected open work area');
+    const store = useThreeDStore.getState();
+    store.upsertAvatar({
+      id: 'local',
+      displayName: 'Alex',
+      roomId: openWork.id,
+      isLocal: true,
+    });
+
+    const first = useThreeDStore.getState().avatars;
+    store.upsertAvatar({
+      id: 'local',
+      displayName: 'Alex',
+      roomId: openWork.id,
+      isLocal: true,
+    });
+    const second = useThreeDStore.getState().avatars;
+
+    expect(second).toBe(first);
+  });
+
+  it('keeps the local avatar id stable across duplicate updates', () => {
+    if (!openWork) throw new Error('expected open work area');
+    const store = useThreeDStore.getState();
+    store.upsertAvatar({
+      id: 'local',
+      displayName: 'Alex',
+      roomId: openWork.id,
+      isLocal: true,
+    });
+    expect(useThreeDStore.getState().localAvatarId).toBe('local');
+
+    store.upsertAvatar({
+      id: 'local',
+      displayName: 'Alex',
+      roomId: openWork.id,
+      isLocal: true,
+    });
+    expect(useThreeDStore.getState().localAvatarId).toBe('local');
+  });
+});

--- a/nexspace-frontend/src/features/threeDMode/__tests__/threeDStore.avatars.test.ts
+++ b/nexspace-frontend/src/features/threeDMode/__tests__/threeDStore.avatars.test.ts
@@ -57,4 +57,41 @@ describe('threeDStore avatar updates', () => {
     });
     expect(useThreeDStore.getState().localAvatarId).toBe('local');
   });
+
+  it('does not churn state when syncing an unchanged roster snapshot', () => {
+    if (!openWork) throw new Error('expected open work area');
+    const store = useThreeDStore.getState();
+    store.syncRoster({
+      participants: [
+        {
+          id: 'local',
+          displayName: 'Alex',
+          isLocal: true,
+        },
+      ],
+      fallbackRoomId: openWork.id,
+      explicitLocalId: 'local',
+    });
+
+    const firstAvatars = useThreeDStore.getState().avatars;
+    const firstLocalId = useThreeDStore.getState().localAvatarId;
+
+    store.syncRoster({
+      participants: [
+        {
+          id: 'local',
+          displayName: 'Alex',
+          isLocal: true,
+        },
+      ],
+      fallbackRoomId: openWork.id,
+      explicitLocalId: 'local',
+    });
+
+    const secondAvatars = useThreeDStore.getState().avatars;
+    const secondLocalId = useThreeDStore.getState().localAvatarId;
+
+    expect(secondAvatars).toBe(firstAvatars);
+    expect(secondLocalId).toBe(firstLocalId);
+  });
 });

--- a/nexspace-frontend/src/features/threeDMode/__tests__/threeDStore.avatars.test.ts
+++ b/nexspace-frontend/src/features/threeDMode/__tests__/threeDStore.avatars.test.ts
@@ -13,6 +13,7 @@ describe('threeDStore avatar updates', () => {
       joinNudges: [],
       lastNudgeByAvatar: {},
       minimapWaypoints: {},
+      cameraMode: 'third-person',
     });
   });
 
@@ -93,5 +94,21 @@ describe('threeDStore avatar updates', () => {
 
     expect(secondAvatars).toBe(firstAvatars);
     expect(secondLocalId).toBe(firstLocalId);
+  });
+
+  it('updates heading when the local avatar moves', () => {
+    if (!openWork) throw new Error('expected open work area');
+    const store = useThreeDStore.getState();
+    store.upsertAvatar({
+      id: 'local',
+      displayName: 'Alex',
+      roomId: openWork.id,
+      isLocal: true,
+      position: { x: 0, y: 0 },
+    });
+
+    useThreeDStore.getState().setAvatarPosition('local', { x: 1, y: 0 });
+    const updated = useThreeDStore.getState().avatars['local'];
+    expect(updated.heading).toBeCloseTo(Math.atan2(1, 0));
   });
 });

--- a/nexspace-frontend/src/features/threeDMode/__tests__/threeDStore.joinNudge.test.ts
+++ b/nexspace-frontend/src/features/threeDMode/__tests__/threeDStore.joinNudge.test.ts
@@ -14,6 +14,7 @@ describe('threeDStore join nudge logic', () => {
       lastNudgeByAvatar: {},
       minimapWaypoints: {},
       joinNudgeCooldownMs: 3_000,
+      cameraMode: 'third-person',
     });
 
     useThreeDStore.getState().upsertAvatar({
@@ -21,6 +22,7 @@ describe('threeDStore join nudge logic', () => {
       displayName: 'You',
       roomId: fallbackRoom,
       isLocal: true,
+      position: { x: 0, y: 0 },
     });
   });
 

--- a/nexspace-frontend/src/features/threeDMode/__tests__/threeDStore.joinNudge.test.ts
+++ b/nexspace-frontend/src/features/threeDMode/__tests__/threeDStore.joinNudge.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, beforeEach, it } from 'vitest';
+import { useThreeDStore } from '../store/threeDStore';
+import { defaultRooms } from '../config/rooms';
+
+const fallbackRoom = defaultRooms[0]?.id ?? 'open-work-area';
+
+describe('threeDStore join nudge logic', () => {
+  beforeEach(() => {
+    useThreeDStore.setState({
+      rooms: defaultRooms,
+      localAvatarId: 'local-1',
+      avatars: {},
+      joinNudges: [],
+      lastNudgeByAvatar: {},
+      minimapWaypoints: {},
+      joinNudgeCooldownMs: 3_000,
+    });
+
+    useThreeDStore.getState().upsertAvatar({
+      id: 'local-1',
+      displayName: 'You',
+      roomId: fallbackRoom,
+      isLocal: true,
+    });
+  });
+
+  it('queues a join nudge when a remote avatar enters the local room', () => {
+    useThreeDStore.getState().upsertAvatar({
+      id: 'remote-1',
+      displayName: 'Alex',
+      roomId: fallbackRoom,
+      isLocal: false,
+    });
+
+    const queue = useThreeDStore.getState().joinNudges;
+    expect(queue).toHaveLength(1);
+    expect(queue[0]).toMatchObject({ avatarId: 'remote-1', roomId: fallbackRoom });
+  });
+
+  it('enforces cooldown to avoid duplicate nudges', () => {
+    const store = useThreeDStore.getState();
+    store.upsertAvatar({ id: 'remote-2', displayName: 'Sam', roomId: fallbackRoom, isLocal: false });
+    expect(useThreeDStore.getState().joinNudges).toHaveLength(1);
+
+    store.upsertAvatar({ id: 'remote-2', displayName: 'Sam', roomId: fallbackRoom, isLocal: false });
+    expect(useThreeDStore.getState().joinNudges).toHaveLength(1);
+
+    useThreeDStore.setState((state) => ({
+      lastNudgeByAvatar: { ...state.lastNudgeByAvatar, 'remote-2': Date.now() - 5_000 },
+    }));
+    store.upsertAvatar({ id: 'remote-2', displayName: 'Sam', roomId: fallbackRoom, isLocal: false });
+    expect(useThreeDStore.getState().joinNudges).toHaveLength(2);
+  });
+
+  it('popJoinNudge dequeues items from the front of the queue', () => {
+    const store = useThreeDStore.getState();
+    store.upsertAvatar({ id: 'remote-3', displayName: 'Kai', roomId: fallbackRoom, isLocal: false });
+
+    const popped = useThreeDStore.getState().popJoinNudge();
+    expect(popped?.avatarId).toBe('remote-3');
+    expect(useThreeDStore.getState().joinNudges).toHaveLength(0);
+  });
+});

--- a/nexspace-frontend/src/features/threeDMode/__tests__/threeDStore.layout.test.ts
+++ b/nexspace-frontend/src/features/threeDMode/__tests__/threeDStore.layout.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useThreeDStore } from '../store/threeDStore';
+import { defaultRooms } from '../config/rooms';
+
+const openWork = defaultRooms.find((room) => room.id === 'open-work-area');
+const lounge = defaultRooms.find((room) => room.id === 'lounge-zone');
+
+describe('threeDStore layout distribution', () => {
+  beforeEach(() => {
+    useThreeDStore.setState({
+      rooms: defaultRooms,
+      avatars: {},
+      localAvatarId: null,
+      joinNudges: [],
+      lastNudgeByAvatar: {},
+      minimapWaypoints: {},
+    });
+  });
+
+  it('distributes avatars across rectangular rooms without overlap', () => {
+    if (!openWork || openWork.boundary.type !== 'rect') {
+      throw new Error('expected open work area room definition');
+    }
+
+    const store = useThreeDStore.getState();
+    ['local', 'remote-a', 'remote-b', 'remote-c'].forEach((id, index) => {
+      store.upsertAvatar({
+        id,
+        displayName: `Avatar ${id}`,
+        roomId: openWork.id,
+        isLocal: index === 0,
+      });
+    });
+
+    const avatars = Object.values(useThreeDStore.getState().avatars).filter(
+      (avatar) => avatar.roomId === openWork.id,
+    );
+
+    const keys = new Set(avatars.map((avatar) => `${avatar.position.x.toFixed(2)}:${avatar.position.y.toFixed(2)}`));
+    expect(keys.size).toBe(avatars.length);
+
+    avatars.forEach((avatar) => {
+      expect(avatar.position.x).toBeGreaterThanOrEqual(openWork.boundary.center[0] - openWork.boundary.size[0] / 2);
+      expect(avatar.position.x).toBeLessThanOrEqual(openWork.boundary.center[0] + openWork.boundary.size[0] / 2);
+      expect(avatar.position.y).toBeGreaterThanOrEqual(openWork.boundary.center[1] - openWork.boundary.size[1] / 2);
+      expect(avatar.position.y).toBeLessThanOrEqual(openWork.boundary.center[1] + openWork.boundary.size[1] / 2);
+    });
+  });
+
+  it('arranges avatars around the lounge circle interior', () => {
+    if (!lounge || lounge.boundary.type !== 'circle') {
+      throw new Error('expected lounge zone room definition');
+    }
+
+    const store = useThreeDStore.getState();
+    ['alpha', 'beta', 'gamma', 'delta', 'epsilon'].forEach((id, index) => {
+      store.upsertAvatar({
+        id,
+        displayName: `Guest ${index}`,
+        roomId: lounge.id,
+        isLocal: index === 0,
+      });
+    });
+
+    const avatars = Object.values(useThreeDStore.getState().avatars).filter((avatar) => avatar.roomId === lounge.id);
+
+    const radiusCheck = lounge.boundary.radius * 0.75;
+    avatars.forEach((avatar) => {
+      const dx = avatar.position.x - lounge.boundary.center[0];
+      const dy = avatar.position.y - lounge.boundary.center[1];
+      const distance = Math.sqrt(dx * dx + dy * dy);
+      expect(distance).toBeLessThanOrEqual(radiusCheck);
+      expect(distance).toBeGreaterThan(0.5);
+    });
+  });
+});

--- a/nexspace-frontend/src/features/threeDMode/__tests__/threeDStore.layout.test.ts
+++ b/nexspace-frontend/src/features/threeDMode/__tests__/threeDStore.layout.test.ts
@@ -2,9 +2,6 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { useThreeDStore } from '../store/threeDStore';
 import { defaultRooms } from '../config/rooms';
 
-const openWork = defaultRooms.find((room) => room.id === 'open-work-area');
-const lounge = defaultRooms.find((room) => room.id === 'lounge-zone');
-
 describe('threeDStore layout distribution', () => {
   beforeEach(() => {
     useThreeDStore.setState({
@@ -18,6 +15,7 @@ describe('threeDStore layout distribution', () => {
   });
 
   it('distributes avatars across rectangular rooms without overlap', () => {
+    const openWork = defaultRooms.find((room) => room.id === 'open-work-area');
     if (!openWork || openWork.boundary.type !== 'rect') {
       throw new Error('expected open work area room definition');
     }
@@ -48,6 +46,7 @@ describe('threeDStore layout distribution', () => {
   });
 
   it('arranges avatars around the lounge circle interior', () => {
+    const lounge = defaultRooms.find((room) => room.id === 'lounge-zone');
     if (!lounge || lounge.boundary.type !== 'circle') {
       throw new Error('expected lounge zone room definition');
     }

--- a/nexspace-frontend/src/features/threeDMode/__tests__/threeDStore.layout.test.ts
+++ b/nexspace-frontend/src/features/threeDMode/__tests__/threeDStore.layout.test.ts
@@ -11,6 +11,7 @@ describe('threeDStore layout distribution', () => {
       joinNudges: [],
       lastNudgeByAvatar: {},
       minimapWaypoints: {},
+      cameraMode: 'third-person',
     });
   });
 

--- a/nexspace-frontend/src/features/threeDMode/components/CameraModeToggle.tsx
+++ b/nexspace-frontend/src/features/threeDMode/components/CameraModeToggle.tsx
@@ -1,21 +1,16 @@
 import React from 'react';
-import { useThreeDStore, type QualityLevel } from '../store/threeDStore';
+import { useThreeDStore, type CameraMode } from '../store/threeDStore';
 import { useUIStore } from '../../../stores/uiStore';
 import { getThemeTokens } from '../../../constants/themeTokens';
 
-const QUALITY_OPTIONS: Array<{ value: QualityLevel; label: string; hint: string }> = [
-  { value: 'low', label: 'Low', hint: 'Best for battery & low-end GPUs' },
-  { value: 'medium', label: 'Balanced', hint: 'Default visual fidelity' },
-  { value: 'high', label: 'High', hint: 'Max shadows & post effects' },
+const CAMERA_OPTIONS: Array<{ value: CameraMode; label: string; hint: string }> = [
+  { value: 'third-person', label: 'Third-person', hint: 'Wide, over-the-shoulder campus view' },
+  { value: 'first-person', label: 'First-person', hint: 'Immersive, eye-level walk mode' },
 ];
 
-type QualitySelectorProps = {
-  showHeading?: boolean;
-};
-
-const QualitySelector: React.FC<QualitySelectorProps> = ({ showHeading = true }) => {
-  const quality = useThreeDStore((s) => s.quality);
-  const setQuality = useThreeDStore((s) => s.setQuality);
+const CameraModeToggle: React.FC = () => {
+  const mode = useThreeDStore((s) => s.cameraMode);
+  const setMode = useThreeDStore((s) => s.setCameraMode);
   const theme = useUIStore((s) => s.theme);
   const tokens = getThemeTokens(theme);
 
@@ -24,18 +19,16 @@ const QualitySelector: React.FC<QualitySelectorProps> = ({ showHeading = true })
       className="w-full rounded-3xl border px-4 py-3 shadow-lg backdrop-blur-xl"
       style={{ background: tokens.surface, borderColor: tokens.borderSoft }}
     >
-      {showHeading && (
-        <p className="text-xs uppercase tracking-[0.28em]" style={{ color: tokens.textMuted }}>
-          Quality & Performance
-        </p>
-      )}
-      <div className={`${showHeading ? 'mt-2' : 'mt-1'} flex flex-col gap-2`}>
-        {QUALITY_OPTIONS.map((option) => {
-          const isActive = quality === option.value;
+      <p className="text-xs uppercase tracking-[0.28em]" style={{ color: tokens.textMuted }}>
+        View Mode
+      </p>
+      <div className="mt-2 flex flex-col gap-2">
+        {CAMERA_OPTIONS.map((option) => {
+          const isActive = option.value === mode;
           return (
             <button
               key={option.value}
-              onClick={() => setQuality(option.value)}
+              onClick={() => setMode(option.value)}
               className="flex items-start gap-3 rounded-2xl px-3 py-2 text-left transition"
               style={{
                 background: isActive ? tokens.accentSoft : tokens.surfaceAlt,
@@ -60,4 +53,4 @@ const QualitySelector: React.FC<QualitySelectorProps> = ({ showHeading = true })
   );
 };
 
-export default QualitySelector;
+export default CameraModeToggle;

--- a/nexspace-frontend/src/features/threeDMode/components/JoinNudgePanel.tsx
+++ b/nexspace-frontend/src/features/threeDMode/components/JoinNudgePanel.tsx
@@ -1,0 +1,81 @@
+import React, { useMemo } from 'react';
+import { useThreeDStore } from '../store/threeDStore';
+import { useUIStore } from '../../../stores/uiStore';
+import { getThemeTokens } from '../../../constants/themeTokens';
+
+const JoinNudgePanel: React.FC = () => {
+  const joinNudge = useThreeDStore((s) => s.joinNudges[0] ?? null);
+  const popJoinNudge = useThreeDStore((s) => s.popJoinNudge);
+  const rooms = useThreeDStore((s) => s.rooms);
+  const theme = useUIStore((s) => s.theme);
+  const tokens = getThemeTokens(theme);
+
+  const roomName = useMemo(() => {
+    if (!joinNudge) return null;
+    return rooms.find((room) => room.id === joinNudge.roomId)?.name ?? 'the room';
+  }, [joinNudge, rooms]);
+
+  if (!joinNudge) return null;
+
+  const handleAction = () => {
+    popJoinNudge();
+  };
+
+  return (
+    <div className="absolute left-1/2 top-10 z-20 -translate-x-1/2">
+      <div
+        className="flex w-[min(420px,90vw)] flex-col gap-3 rounded-3xl border px-5 py-4 shadow-xl backdrop-blur-xl"
+        style={{ background: tokens.surface, borderColor: tokens.borderStrong }}
+      >
+        <div className="flex items-center gap-3">
+          <div
+            className="grid h-10 w-10 place-items-center rounded-2xl"
+            style={{ background: tokens.accentSoft }}
+          >
+            <span aria-hidden className="text-lg" role="img">
+              👋
+            </span>
+          </div>
+          <div className="flex-1">
+            <p className="text-sm font-semibold" style={{ color: tokens.textPrimary }}>
+              {joinNudge.displayName} just entered {roomName}
+            </p>
+            <p className="text-xs" style={{ color: tokens.textSecondary }}>
+              Give them a warm welcome or launch a quick huddle.
+            </p>
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {[
+            { label: 'Wave hello', icon: '🖐️' },
+            { label: 'Invite to huddle', icon: '🎯' },
+            { label: 'Send DM', icon: '💬' },
+          ].map((action) => (
+            <button
+              key={action.label}
+              onClick={handleAction}
+              className="flex flex-1 min-w-[120px] items-center justify-center gap-2 rounded-2xl px-3 py-2 text-sm font-medium transition"
+              style={{
+                background: tokens.surfaceAlt,
+                color: tokens.textPrimary,
+                border: `1px solid ${tokens.borderSoft}`,
+              }}
+            >
+              <span aria-hidden>{action.icon}</span>
+              {action.label}
+            </button>
+          ))}
+        </div>
+        <button
+          onClick={handleAction}
+          className="self-end text-xs font-semibold uppercase tracking-[0.3em]"
+          style={{ color: tokens.textMuted }}
+        >
+          dismiss
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default JoinNudgePanel;

--- a/nexspace-frontend/src/features/threeDMode/components/JoinNudgePanel.tsx
+++ b/nexspace-frontend/src/features/threeDMode/components/JoinNudgePanel.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { useThreeDStore } from '../store/threeDStore';
 import { useUIStore } from '../../../stores/uiStore';
 import { getThemeTokens } from '../../../constants/themeTokens';
+import { useMeetingStore } from '../../../stores/meetingStore';
 
 const JoinNudgePanel: React.FC = () => {
   const joinNudge = useThreeDStore((s) => s.joinNudges[0] ?? null);
@@ -17,7 +18,29 @@ const JoinNudgePanel: React.FC = () => {
 
   if (!joinNudge) return null;
 
-  const handleAction = () => {
+  const handleWave = () => {
+    const meeting = useMeetingStore.getState();
+    const message = `👋 says hi to ${joinNudge.displayName}${roomName ? ` in ${roomName}` : ''}!`;
+    void meeting.sendMessage(message);
+    popJoinNudge();
+  };
+
+  const handleInvite = () => {
+    const meeting = useMeetingStore.getState();
+    void meeting.startWhisper(joinNudge.avatarId);
+    popJoinNudge();
+  };
+
+  const handleDM = () => {
+    const meeting = useMeetingStore.getState();
+    if (!meeting.chatOpen) {
+      meeting.toggleChat();
+    }
+    meeting.setActiveDMPeer(joinNudge.avatarId);
+    popJoinNudge();
+  };
+
+  const handleDismiss = () => {
     popJoinNudge();
   };
 
@@ -46,28 +69,45 @@ const JoinNudgePanel: React.FC = () => {
           </div>
         </div>
         <div className="flex flex-wrap gap-2">
-          {[
-            { label: 'Wave hello', icon: '🖐️' },
-            { label: 'Invite to huddle', icon: '🎯' },
-            { label: 'Send DM', icon: '💬' },
-          ].map((action) => (
-            <button
-              key={action.label}
-              onClick={handleAction}
-              className="flex flex-1 min-w-[120px] items-center justify-center gap-2 rounded-2xl px-3 py-2 text-sm font-medium transition"
-              style={{
-                background: tokens.surfaceAlt,
-                color: tokens.textPrimary,
-                border: `1px solid ${tokens.borderSoft}`,
-              }}
-            >
-              <span aria-hidden>{action.icon}</span>
-              {action.label}
-            </button>
-          ))}
+          <button
+            onClick={handleWave}
+            className="flex flex-1 min-w-[120px] items-center justify-center gap-2 rounded-2xl px-3 py-2 text-sm font-medium transition"
+            style={{
+              background: tokens.surfaceAlt,
+              color: tokens.textPrimary,
+              border: `1px solid ${tokens.borderSoft}`,
+            }}
+          >
+            <span aria-hidden>🖐️</span>
+            Wave hello
+          </button>
+          <button
+            onClick={handleInvite}
+            className="flex flex-1 min-w-[120px] items-center justify-center gap-2 rounded-2xl px-3 py-2 text-sm font-medium transition"
+            style={{
+              background: tokens.surfaceAlt,
+              color: tokens.textPrimary,
+              border: `1px solid ${tokens.borderSoft}`,
+            }}
+          >
+            <span aria-hidden>🎯</span>
+            Invite to huddle
+          </button>
+          <button
+            onClick={handleDM}
+            className="flex flex-1 min-w-[120px] items-center justify-center gap-2 rounded-2xl px-3 py-2 text-sm font-medium transition"
+            style={{
+              background: tokens.surfaceAlt,
+              color: tokens.textPrimary,
+              border: `1px solid ${tokens.borderSoft}`,
+            }}
+          >
+            <span aria-hidden>💬</span>
+            Send DM
+          </button>
         </div>
         <button
-          onClick={handleAction}
+          onClick={handleDismiss}
           className="self-end text-xs font-semibold uppercase tracking-[0.3em]"
           style={{ color: tokens.textMuted }}
         >

--- a/nexspace-frontend/src/features/threeDMode/components/QualitySelector.tsx
+++ b/nexspace-frontend/src/features/threeDMode/components/QualitySelector.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { useThreeDStore, type QualityLevel } from '../store/threeDStore';
+import { useUIStore } from '../../../stores/uiStore';
+import { getThemeTokens } from '../../../constants/themeTokens';
+
+const QUALITY_OPTIONS: Array<{ value: QualityLevel; label: string; hint: string }> = [
+  { value: 'low', label: 'Low', hint: 'Best for battery & low-end GPUs' },
+  { value: 'medium', label: 'Balanced', hint: 'Default visual fidelity' },
+  { value: 'high', label: 'High', hint: 'Max shadows & post effects' },
+];
+
+const QualitySelector: React.FC = () => {
+  const quality = useThreeDStore((s) => s.quality);
+  const setQuality = useThreeDStore((s) => s.setQuality);
+  const theme = useUIStore((s) => s.theme);
+  const tokens = getThemeTokens(theme);
+
+  return (
+    <div
+      className="w-[min(360px,80vw)] rounded-3xl border px-4 py-3 shadow-lg backdrop-blur-xl"
+      style={{ background: tokens.surface, borderColor: tokens.borderSoft }}
+    >
+      <p className="text-xs uppercase tracking-[0.28em]" style={{ color: tokens.textMuted }}>
+        Quality & Performance
+      </p>
+      <div className="mt-2 flex flex-col gap-2">
+        {QUALITY_OPTIONS.map((option) => {
+          const isActive = quality === option.value;
+          return (
+            <button
+              key={option.value}
+              onClick={() => setQuality(option.value)}
+              className="flex items-start gap-3 rounded-2xl px-3 py-2 text-left transition"
+              style={{
+                background: isActive ? tokens.accentSoft : tokens.surfaceAlt,
+                border: `1px solid ${isActive ? tokens.accent : tokens.borderSoft}`,
+                color: tokens.textPrimary,
+              }}
+            >
+              <span className="mt-0.5 text-base" aria-hidden>
+                {isActive ? '●' : '○'}
+              </span>
+              <span className="flex-1">
+                <span className="block text-sm font-semibold">{option.label}</span>
+                <span className="mt-1 block text-xs" style={{ color: tokens.textSecondary }}>
+                  {option.hint}
+                </span>
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default QualitySelector;

--- a/nexspace-frontend/src/features/threeDMode/components/ThreeDExperience.tsx
+++ b/nexspace-frontend/src/features/threeDMode/components/ThreeDExperience.tsx
@@ -1,13 +1,16 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState, useCallback } from 'react';
 import { useThreeDStore } from '../store/threeDStore';
 import { useUIStore } from '../../../stores/uiStore';
 import { getThemeTokens } from '../../../constants/themeTokens';
 import ThreeDMinimap from './ThreeDMinimap';
 import JoinNudgePanel from './JoinNudgePanel';
 import QualitySelector from './QualitySelector';
+import CameraModeToggle from './CameraModeToggle';
 import { useThreeDAvatarSync } from '../hooks/useThreeDAvatarSync';
 import ThreeDScene from './ThreeDScene';
 import { useSpatialAudioRouting } from '../hooks/useSpatialAudioRouting';
+
+type PanelKey = 'status' | 'map' | 'settings';
 
 const ThreeDExperience: React.FC = () => {
   useThreeDAvatarSync();
@@ -36,70 +39,143 @@ const ThreeDExperience: React.FC = () => {
     [rooms, avatars, localAvatarId],
   );
 
+  const totalAvatars = useMemo(() => Object.keys(avatars).length, [avatars]);
+
+  const [openPanel, setOpenPanel] = useState<PanelKey>('status');
+
+  const renderStatusPanel = useCallback(
+    () => (
+      <div className="space-y-2">
+        {roomSummaries.map(({ room, occupants, localInside }) => (
+          <div
+            key={room.id}
+            className="flex items-start justify-between gap-3 rounded-2xl border px-3 py-2"
+            style={{
+              borderColor: localInside ? tokens.accent : tokens.borderSoft,
+              background: localInside ? tokens.accentSoft : tokens.surfaceAlt,
+              color: tokens.textPrimary,
+            }}
+          >
+            <div>
+              <p className="text-sm font-semibold" style={{ color: tokens.textPrimary }}>
+                {room.name}
+              </p>
+              {room.signage && (
+                <p className="text-[11px] leading-relaxed" style={{ color: tokens.textSecondary }}>
+                  {room.signage}
+                </p>
+              )}
+            </div>
+            <div className="text-right">
+              <span className="block text-xs font-medium" style={{ color: tokens.textSecondary }}>
+                {occupants.length} {occupants.length === 1 ? 'person' : 'people'}
+              </span>
+              <span className="mt-0.5 inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] uppercase"
+                style={{
+                  background: tokens.surface,
+                  color: tokens.textMuted,
+                  border: `1px solid ${tokens.borderSoft}`,
+                }}
+              >
+                {room.audio.roomIsolation >= 0.8 ? 'Private' : room.audio.roomIsolation >= 0.5 ? 'Semi-open' : 'Open'}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+    ),
+    [roomSummaries, tokens],
+  );
+
+  const panels = useMemo(
+    () =>
+      [
+        {
+          key: 'status' as PanelKey,
+          title: 'Rooms & Presence',
+          subtitle: `${rooms.length} zones • ${totalAvatars} teammates`,
+          render: renderStatusPanel,
+        },
+        {
+          key: 'map' as PanelKey,
+          title: 'Minimap',
+          subtitle: 'Set a waypoint or scout ahead',
+          render: () => <ThreeDMinimap showHeader={false} />,
+        },
+        {
+          key: 'settings' as PanelKey,
+          title: 'Immersive Controls',
+          subtitle: `Quality ${quality.toUpperCase()} • ${theme === 'dark' ? 'Dark' : 'Light'} theme`,
+          render: () => (
+            <div className="space-y-3">
+              <QualitySelector showHeading={false} />
+              <CameraModeToggle />
+            </div>
+          ),
+        },
+      ],
+    [quality, renderStatusPanel, rooms.length, theme, totalAvatars],
+  );
+
+  const handlePanelToggle = (key: PanelKey) => {
+    if (openPanel !== key) {
+      setOpenPanel(key);
+    }
+  };
+
   return (
     <div className="relative h-full w-full overflow-hidden" style={{ backgroundColor: tokens.background }}>
       <ThreeDScene />
 
       <div className="pointer-events-none absolute inset-0" style={gradientStyle} />
 
-      <div className="pointer-events-none absolute left-6 top-6 w-[320px] max-w-[85vw]">
-        <div
-          className="rounded-3xl border px-5 py-4 shadow-2xl backdrop-blur-xl"
-          style={{
-            background: tokens.surface,
-            borderColor: tokens.borderSoft,
-          }}
-        >
-          <p className="text-xs uppercase tracking-[0.32em]" style={{ color: tokens.textMuted }}>
-            Spatial status
-          </p>
-          <h2 className="mt-2 text-lg font-semibold" style={{ color: tokens.textPrimary }}>
-            Campus overview
-          </h2>
-          <p className="mt-2 text-xs" style={{ color: tokens.textSecondary }}>
-            Quality {quality.toUpperCase()} • {rooms.length} zones active • {Object.keys(avatars).length} teammates synced
-          </p>
-          <div className="mt-4 space-y-2">
-            {roomSummaries.map(({ room, occupants, localInside }) => (
-                <div
-                  key={room.id}
-                  className="flex items-start justify-between gap-3 rounded-2xl border px-3 py-2"
-                  style={{
-                    borderColor: localInside ? tokens.accent : tokens.borderSoft,
-                    background: localInside ? tokens.accentSoft : tokens.surfaceAlt,
-                    color: tokens.textPrimary,
-                  }}
-                >
-                  <div>
-                    <p className="text-sm font-semibold" style={{ color: tokens.textPrimary }}>
-                      {room.name}
-                    </p>
-                    {room.signage && (
-                      <p className="text-[11px] leading-relaxed" style={{ color: tokens.textSecondary }}>
-                        {room.signage}
-                      </p>
-                    )}
-                  </div>
-                  <span className="text-xs font-medium" style={{ color: tokens.textSecondary }}>
-                    {occupants.length} in room
-                  </span>
+      <div className="pointer-events-none absolute right-6 top-6 flex w-[min(360px,90vw)] flex-col gap-4">
+        {panels.map((panel) => {
+          const isOpen = openPanel === panel.key;
+          return (
+            <div
+              key={panel.key}
+              className="pointer-events-auto overflow-hidden rounded-3xl border shadow-2xl backdrop-blur-xl transition"
+              style={{
+                background: tokens.surface,
+                borderColor: tokens.borderSoft,
+                maxHeight: isOpen ? '640px' : '68px',
+              }}
+            >
+              <button
+                type="button"
+                onClick={() => handlePanelToggle(panel.key)}
+                className="flex w-full items-center justify-between gap-3 px-5 py-4 text-left"
+                style={{ color: tokens.textPrimary }}
+              >
+                <div>
+                  <p className="text-xs uppercase tracking-[0.28em]" style={{ color: tokens.textMuted }}>
+                    {panel.title}
+                  </p>
+                  <p className="mt-1 text-sm font-semibold" style={{ color: tokens.textPrimary }}>
+                    {panel.subtitle}
+                  </p>
                 </div>
-              ))}
-          </div>
-        </div>
-      </div>
-
-      <div className="absolute left-6 bottom-6 w-72 max-w-[85vw]">
-        <ThreeDMinimap />
-      </div>
-
-      <div className="absolute right-6 top-6">
-        <QualitySelector />
+                <span
+                  aria-hidden
+                  className={`text-lg transition-transform ${isOpen ? 'rotate-90' : 'rotate-0'}`}
+                  style={{ color: tokens.textSecondary }}
+                >
+                  ➤
+                </span>
+              </button>
+              {isOpen && <div className="px-5 pb-5">{panel.render()}</div>}
+            </div>
+          );
+        })}
       </div>
 
       <JoinNudgePanel />
 
-      <div className="pointer-events-none absolute bottom-4 right-6 text-[11px] uppercase tracking-[0.32em]" style={{ color: tokens.textMuted }}>
+      <div
+        className="pointer-events-none absolute bottom-4 right-6 text-[11px] uppercase tracking-[0.32em]"
+        style={{ color: tokens.textMuted }}
+      >
         Theme: {theme.toUpperCase()}
       </div>
     </div>

--- a/nexspace-frontend/src/features/threeDMode/components/ThreeDExperience.tsx
+++ b/nexspace-frontend/src/features/threeDMode/components/ThreeDExperience.tsx
@@ -1,0 +1,85 @@
+import React, { useMemo } from 'react';
+import { useThreeDStore } from '../store/threeDStore';
+import { useUIStore } from '../../../stores/uiStore';
+import { getThemeTokens } from '../../../constants/themeTokens';
+import ThreeDMinimap from './ThreeDMinimap';
+import JoinNudgePanel from './JoinNudgePanel';
+import QualitySelector from './QualitySelector';
+import { useThreeDAvatarSync } from '../hooks/useThreeDAvatarSync';
+
+const ThreeDExperience: React.FC = () => {
+  useThreeDAvatarSync();
+  const theme = useUIStore((s) => s.theme);
+  const tokens = getThemeTokens(theme);
+  const quality = useThreeDStore((s) => s.quality);
+  const rooms = useThreeDStore((s) => s.rooms);
+
+  const gradientStyle = useMemo(
+    () => ({
+      background: `radial-gradient(circle at 22% 18%, ${tokens.surfaceAlt} 0%, ${tokens.background} 58%)`,
+    }),
+    [tokens]
+  );
+
+  return (
+    <div
+      className="relative h-full w-full overflow-hidden"
+      style={{ backgroundColor: tokens.background, color: tokens.textPrimary }}
+    >
+      <div className="absolute inset-0" style={gradientStyle}>
+        <div
+          aria-hidden
+          className="absolute inset-0"
+          style={{
+            backgroundImage: `linear-gradient(135deg, ${tokens.gridLine} 1px, transparent 1px), linear-gradient(45deg, ${tokens.gridLine} 1px, transparent 1px)`,
+            backgroundSize: '32px 32px',
+            opacity: 0.25,
+          }}
+        />
+        <div className="relative flex h-full w-full items-center justify-center">
+          <div
+            className="pointer-events-none max-w-lg rounded-3xl border px-6 py-6 text-center shadow-2xl backdrop-blur-xl"
+            style={{
+              background: tokens.surface,
+              borderColor: tokens.borderStrong,
+            }}
+          >
+            <h2 className="text-lg font-semibold" style={{ color: tokens.textPrimary }}>
+              Immersive campus preview
+            </h2>
+            <p className="mt-3 text-sm leading-relaxed" style={{ color: tokens.textSecondary }}>
+              The spatial workspace is syncing avatars, minimap presence, and welcome nudges while
+              the realtime 3D stage is constructed. Visual fidelity adapts to your selected quality
+              mode.
+            </p>
+            <p className="mt-4 text-xs uppercase tracking-[0.32em]" style={{ color: tokens.textMuted }}>
+              Quality: {quality.toUpperCase()}
+            </p>
+            <p className="mt-2 text-xs" style={{ color: tokens.textMuted }}>
+              Rooms configured: {rooms.length}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="absolute left-6 bottom-6 w-72 max-w-[85vw]">
+        <ThreeDMinimap />
+      </div>
+
+      <div className="absolute right-6 top-6">
+        <QualitySelector />
+      </div>
+
+      <JoinNudgePanel />
+
+      <div
+        className="pointer-events-none absolute bottom-4 right-6 text-[11px] uppercase tracking-[0.32em]"
+        style={{ color: tokens.textMuted }}
+      >
+        Theme: {theme.toUpperCase()}
+      </div>
+    </div>
+  );
+};
+
+export default ThreeDExperience;

--- a/nexspace-frontend/src/features/threeDMode/components/ThreeDExperience.tsx
+++ b/nexspace-frontend/src/features/threeDMode/components/ThreeDExperience.tsx
@@ -7,9 +7,11 @@ import JoinNudgePanel from './JoinNudgePanel';
 import QualitySelector from './QualitySelector';
 import { useThreeDAvatarSync } from '../hooks/useThreeDAvatarSync';
 import ThreeDScene from './ThreeDScene';
+import { useSpatialAudioRouting } from '../hooks/useSpatialAudioRouting';
 
 const ThreeDExperience: React.FC = () => {
   useThreeDAvatarSync();
+  useSpatialAudioRouting();
   const theme = useUIStore((s) => s.theme);
   const tokens = getThemeTokens(theme);
   const quality = useThreeDStore((s) => s.quality);

--- a/nexspace-frontend/src/features/threeDMode/components/ThreeDMinimap.tsx
+++ b/nexspace-frontend/src/features/threeDMode/components/ThreeDMinimap.tsx
@@ -1,15 +1,51 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 import { useThreeDStore } from '../store/threeDStore';
 import { useUIStore } from '../../../stores/uiStore';
 import { getThemeTokens } from '../../../constants/themeTokens';
+import { computeCampusBounds } from '../utils/spatial';
+import type { RoomDefinition } from '../config/rooms';
 
 const MAX_NAME_TAGS = 4;
+
+const roomColorFor = (rooms: RoomDefinition[], roomId: string | undefined, fallback: string): string => {
+  if (!roomId) return fallback;
+  return rooms.find((room) => room.id === roomId)?.themeColor ?? fallback;
+};
 
 const ThreeDMinimap: React.FC = () => {
   const rooms = useThreeDStore((s) => s.rooms);
   const avatars = useThreeDStore((s) => s.avatars);
+  const localAvatarId = useThreeDStore((s) => s.localAvatarId);
+  const waypoints = useThreeDStore((s) => s.minimapWaypoints);
+  const markWaypoint = useThreeDStore((s) => s.markWaypoint);
   const theme = useUIStore((s) => s.theme);
   const tokens = getThemeTokens(theme);
+
+  const svgRef = useRef<SVGSVGElement | null>(null);
+
+  const campusBounds = useMemo(() => computeCampusBounds(rooms), [rooms]);
+
+  const viewBox = useMemo(() => {
+    if (!campusBounds) return '-10 -10 20 20';
+    const margin = 4;
+    return `${campusBounds.minX - margin} ${campusBounds.minY - margin} ${
+      campusBounds.width + margin * 2
+    } ${campusBounds.height + margin * 2}`;
+  }, [campusBounds]);
+
+  const projectedAvatars = useMemo(
+    () =>
+      Object.values(avatars).map((avatar) => ({
+        ...avatar,
+        waypoint: waypoints[avatar.id] ?? null,
+      })),
+    [avatars, waypoints],
+  );
+
+  const localRoomId = useMemo(() => {
+    const localAvatar = projectedAvatars.find((avatar) => avatar.id === localAvatarId);
+    return localAvatar?.roomId;
+  }, [localAvatarId, projectedAvatars]);
 
   const summary = useMemo(
     () =>
@@ -26,6 +62,26 @@ const ThreeDMinimap: React.FC = () => {
   );
 
   const totalAvatars = useMemo(() => Object.keys(avatars).length, [avatars]);
+
+  const handleMapClick = useCallback(
+    (event: React.MouseEvent<SVGSVGElement>) => {
+      if (!localAvatarId) return;
+      const svg = svgRef.current;
+      if (!svg) return;
+      const point = svg.createSVGPoint();
+      point.x = event.clientX;
+      point.y = event.clientY;
+      const screenCTM = svg.getScreenCTM();
+      if (!screenCTM) return;
+      const cursor = point.matrixTransform(screenCTM.inverse());
+      if (event.altKey) {
+        markWaypoint(localAvatarId, null);
+        return;
+      }
+      markWaypoint(localAvatarId, { x: cursor.x, y: cursor.y });
+    },
+    [localAvatarId, markWaypoint],
+  );
 
   return (
     <div
@@ -48,6 +104,118 @@ const ThreeDMinimap: React.FC = () => {
           {totalAvatars} online
         </span>
       </div>
+      <div
+        className="mx-4 mt-3 rounded-2xl border"
+        style={{
+          borderColor: tokens.borderSoft,
+          background: tokens.surfaceAlt,
+        }}
+      >
+        <svg
+          ref={svgRef}
+          viewBox={viewBox}
+          className="h-48 w-full cursor-pointer"
+          role="img"
+          aria-label="Campus minimap"
+          onClick={handleMapClick}
+        >
+          <defs>
+            <radialGradient id="minimap-glow" cx="50%" cy="50%" r="60%">
+              <stop offset="0%" stopColor={tokens.surfaceAlpha} stopOpacity={0.8} />
+              <stop offset="100%" stopColor={tokens.surface} stopOpacity={0} />
+            </radialGradient>
+          </defs>
+          <rect
+            x={campusBounds ? campusBounds.minX - 6 : -12}
+            y={campusBounds ? campusBounds.minY - 6 : -12}
+            width={campusBounds ? campusBounds.width + 12 : 24}
+            height={campusBounds ? campusBounds.height + 12 : 24}
+            fill="url(#minimap-glow)"
+          />
+          {rooms.map((room) => {
+            const boundary = room.boundary;
+            const stroke = room.id === localRoomId ? tokens.accent : tokens.borderSoft;
+            if (boundary.type === 'rect') {
+              const [cx, cy] = boundary.center;
+              const [w, h] = boundary.size;
+              const rotation = ((boundary.rotation ?? 0) * 180) / Math.PI;
+              return (
+                <rect
+                  key={room.id}
+                  x={cx - w / 2}
+                  y={cy - h / 2}
+                  width={w}
+                  height={h}
+                  rx={1.2}
+                  ry={1.2}
+                  fill={room.id === localRoomId ? tokens.accentSoft : tokens.surface}
+                  stroke={stroke}
+                  strokeWidth={0.3}
+                  opacity={0.9}
+                  transform={rotation ? `rotate(${rotation} ${cx} ${cy})` : undefined}
+                />
+              );
+            }
+            return (
+              <circle
+                key={room.id}
+                cx={boundary.center[0]}
+                cy={boundary.center[1]}
+                r={boundary.radius}
+                fill={room.id === localRoomId ? tokens.accentSoft : tokens.surface}
+                stroke={stroke}
+                strokeWidth={0.4}
+                opacity={0.92}
+              />
+            );
+          })}
+          {projectedAvatars.map((avatar) => {
+            const radius = avatar.isLocal ? 0.65 : 0.45;
+            return (
+              <g key={avatar.id}>
+                <circle
+                  cx={avatar.position.x}
+                  cy={avatar.position.y}
+                  r={radius}
+                  fill={avatar.isLocal ? tokens.accent : roomColorFor(rooms, avatar.roomId, tokens.textSecondary)}
+                  stroke={avatar.isLocal ? tokens.surface : tokens.surfaceAlpha}
+                  strokeWidth={avatar.isLocal ? 0.2 : 0.1}
+                  opacity={0.95}
+                />
+                {avatar.waypoint && (
+                  <line
+                    x1={avatar.position.x}
+                    y1={avatar.position.y}
+                    x2={avatar.waypoint.x}
+                    y2={avatar.waypoint.y}
+                    stroke={avatar.isLocal ? tokens.accent : tokens.textMuted}
+                    strokeOpacity={avatar.isLocal ? 0.7 : 0.4}
+                    strokeWidth={avatar.isLocal ? 0.25 : 0.18}
+                    strokeDasharray={avatar.isLocal ? '1 0.6' : '0.4 0.6'}
+                  />
+                )}
+                {avatar.waypoint && (
+                  <circle
+                    cx={avatar.waypoint.x}
+                    cy={avatar.waypoint.y}
+                    r={avatar.isLocal ? 0.55 : 0.4}
+                    fill="none"
+                    stroke={avatar.isLocal ? tokens.accent : tokens.textSecondary}
+                    strokeWidth={avatar.isLocal ? 0.25 : 0.18}
+                    strokeOpacity={avatar.isLocal ? 0.8 : 0.55}
+                  />
+                )}
+              </g>
+            );
+          })}
+        </svg>
+        <div className="flex items-center justify-between px-3 py-2 text-[11px]" style={{ color: tokens.textSecondary }}>
+          <span>Click to set a waypoint</span>
+          <span className="text-[10px]" style={{ color: tokens.textMuted }}>
+            Alt+Click to clear
+          </span>
+        </div>
+      </div>
       <ul className="mt-3 space-y-2 px-4 pb-4">
         {summary.map(({ room, occupants, localInside }) => {
           const highlightColor = localInside ? tokens.accent : room.themeColor;
@@ -56,7 +224,20 @@ const ThreeDMinimap: React.FC = () => {
           return (
             <li
               key={room.id}
-              className="rounded-2xl border px-3 py-2 transition-colors"
+              className="cursor-pointer rounded-2xl border px-3 py-2 transition-colors"
+              onClick={(event) => {
+                if (!localAvatarId) return;
+                if (event.altKey) {
+                  markWaypoint(localAvatarId, null);
+                  return;
+                }
+                const boundary = room.boundary;
+                const target =
+                  boundary.type === 'rect'
+                    ? { x: boundary.center[0], y: boundary.center[1] }
+                    : { x: boundary.center[0], y: boundary.center[1] };
+                markWaypoint(localAvatarId, target);
+              }}
               style={{
                 borderColor: localInside ? tokens.accent : tokens.borderSoft,
                 background: localInside ? tokens.accentSoft : tokens.surfaceAlt,

--- a/nexspace-frontend/src/features/threeDMode/components/ThreeDMinimap.tsx
+++ b/nexspace-frontend/src/features/threeDMode/components/ThreeDMinimap.tsx
@@ -1,0 +1,117 @@
+import React, { useMemo } from 'react';
+import { useThreeDStore } from '../store/threeDStore';
+import { useUIStore } from '../../../stores/uiStore';
+import { getThemeTokens } from '../../../constants/themeTokens';
+
+const MAX_NAME_TAGS = 4;
+
+const ThreeDMinimap: React.FC = () => {
+  const rooms = useThreeDStore((s) => s.rooms);
+  const avatars = useThreeDStore((s) => s.avatars);
+  const theme = useUIStore((s) => s.theme);
+  const tokens = getThemeTokens(theme);
+
+  const summary = useMemo(
+    () =>
+      rooms.map((room) => {
+        const occupants = Object.values(avatars).filter((avatar) => avatar.roomId === room.id);
+        const localInside = occupants.some((avatar) => avatar.isLocal);
+        return {
+          room,
+          occupants,
+          localInside,
+        };
+      }),
+    [rooms, avatars]
+  );
+
+  const totalAvatars = useMemo(() => Object.keys(avatars).length, [avatars]);
+
+  return (
+    <div
+      className="rounded-3xl border shadow-2xl backdrop-blur-xl"
+      style={{
+        borderColor: tokens.borderSoft,
+        background: tokens.surface,
+      }}
+    >
+      <div className="flex items-center justify-between px-4 pt-3">
+        <div>
+          <p className="text-xs uppercase tracking-[0.28em]" style={{ color: tokens.textMuted }}>
+            Minimap
+          </p>
+          <p className="text-sm font-semibold" style={{ color: tokens.textPrimary }}>
+            Live campus overview
+          </p>
+        </div>
+        <span className="text-xs font-medium" style={{ color: tokens.textSecondary }}>
+          {totalAvatars} online
+        </span>
+      </div>
+      <ul className="mt-3 space-y-2 px-4 pb-4">
+        {summary.map(({ room, occupants, localInside }) => {
+          const highlightColor = localInside ? tokens.accent : room.themeColor;
+          const occupantNames = occupants.slice(0, MAX_NAME_TAGS);
+          const overflow = occupants.length - occupantNames.length;
+          return (
+            <li
+              key={room.id}
+              className="rounded-2xl border px-3 py-2 transition-colors"
+              style={{
+                borderColor: localInside ? tokens.accent : tokens.borderSoft,
+                background: localInside ? tokens.accentSoft : tokens.surfaceAlt,
+              }}
+            >
+              <div className="flex items-center justify-between gap-4">
+                <div className="flex items-center gap-2">
+                  <span
+                    aria-hidden
+                    className="h-2.5 w-2.5 rounded-full"
+                    style={{ background: highlightColor }}
+                  />
+                  <span className="text-sm font-semibold" style={{ color: tokens.textPrimary }}>
+                    {room.name}
+                  </span>
+                </div>
+                <span className="text-xs" style={{ color: tokens.textSecondary }}>
+                  {occupants.length} inside
+                </span>
+              </div>
+              {occupantNames.length > 0 && (
+                <div className="mt-2 flex flex-wrap gap-1 text-[11px]">
+                  {occupantNames.map((avatar) => (
+                    <span
+                      key={avatar.id}
+                      className="rounded-full px-2 py-0.5"
+                      style={{
+                        background: localInside ? tokens.surface : tokens.surfaceAlpha,
+                        color: tokens.textSecondary,
+                      }}
+                    >
+                      {avatar.displayName}
+                    </span>
+                  ))}
+                  {overflow > 0 && (
+                    <span
+                      className="rounded-full px-2 py-0.5"
+                      style={{ background: tokens.surfaceAlpha, color: tokens.textSecondary }}
+                    >
+                      +{overflow}
+                    </span>
+                  )}
+                </div>
+              )}
+              {room.signage && (
+                <p className="mt-2 text-[11px] leading-relaxed" style={{ color: tokens.textMuted }}>
+                  {room.signage}
+                </p>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};
+
+export default ThreeDMinimap;

--- a/nexspace-frontend/src/features/threeDMode/components/ThreeDMinimap.tsx
+++ b/nexspace-frontend/src/features/threeDMode/components/ThreeDMinimap.tsx
@@ -12,7 +12,11 @@ const roomColorFor = (rooms: RoomDefinition[], roomId: string | undefined, fallb
   return rooms.find((room) => room.id === roomId)?.themeColor ?? fallback;
 };
 
-const ThreeDMinimap: React.FC = () => {
+type ThreeDMinimapProps = {
+  showHeader?: boolean;
+};
+
+const ThreeDMinimap: React.FC<ThreeDMinimapProps> = ({ showHeader = true }) => {
   const rooms = useThreeDStore((s) => s.rooms);
   const avatars = useThreeDStore((s) => s.avatars);
   const localAvatarId = useThreeDStore((s) => s.localAvatarId);
@@ -85,27 +89,29 @@ const ThreeDMinimap: React.FC = () => {
 
   return (
     <div
-      className="rounded-3xl border shadow-2xl backdrop-blur-xl"
+      className="w-full rounded-3xl border shadow-2xl backdrop-blur-xl"
       style={{
         borderColor: tokens.borderSoft,
         background: tokens.surface,
       }}
     >
-      <div className="flex items-center justify-between px-4 pt-3">
-        <div>
-          <p className="text-xs uppercase tracking-[0.28em]" style={{ color: tokens.textMuted }}>
-            Minimap
-          </p>
-          <p className="text-sm font-semibold" style={{ color: tokens.textPrimary }}>
-            Live campus overview
-          </p>
+      {showHeader && (
+        <div className="flex items-center justify-between px-4 pt-3">
+          <div>
+            <p className="text-xs uppercase tracking-[0.28em]" style={{ color: tokens.textMuted }}>
+              Minimap
+            </p>
+            <p className="text-sm font-semibold" style={{ color: tokens.textPrimary }}>
+              Live campus overview
+            </p>
+          </div>
+          <span className="text-xs font-medium" style={{ color: tokens.textSecondary }}>
+            {totalAvatars} online
+          </span>
         </div>
-        <span className="text-xs font-medium" style={{ color: tokens.textSecondary }}>
-          {totalAvatars} online
-        </span>
-      </div>
+      )}
       <div
-        className="mx-4 mt-3 rounded-2xl border"
+        className={`mx-4 ${showHeader ? 'mt-3' : 'mt-4'} rounded-2xl border`}
         style={{
           borderColor: tokens.borderSoft,
           background: tokens.surfaceAlt,

--- a/nexspace-frontend/src/features/threeDMode/components/ThreeDScene.tsx
+++ b/nexspace-frontend/src/features/threeDMode/components/ThreeDScene.tsx
@@ -3,6 +3,7 @@ import * as THREE from 'three';
 import { useThreeDStore } from '../store/threeDStore';
 import { useUIStore } from '../../../stores/uiStore';
 import { getThemeTokens } from '../../../constants/themeTokens';
+import { useThreeDMovement } from '../hooks/useThreeDMovement';
 
 const FLOOR_HEIGHT = 0.08;
 const AVATAR_HEIGHT = 1.65;
@@ -231,6 +232,8 @@ const ThreeDScene: React.FC = () => {
   const avatarGroupRef = useRef<THREE.Group>();
   const roomsGroupRef = useRef<THREE.Group>();
   const clockRef = useRef(new THREE.Clock());
+
+  useThreeDMovement();
 
   const theme = useUIStore((state) => state.theme);
   const tokens = getThemeTokens(theme);

--- a/nexspace-frontend/src/features/threeDMode/components/ThreeDScene.tsx
+++ b/nexspace-frontend/src/features/threeDMode/components/ThreeDScene.tsx
@@ -1,0 +1,502 @@
+import React, { useEffect, useMemo, useRef } from 'react';
+import * as THREE from 'three';
+import { useThreeDStore } from '../store/threeDStore';
+import { useUIStore } from '../../../stores/uiStore';
+import { getThemeTokens } from '../../../constants/themeTokens';
+
+const FLOOR_HEIGHT = 0.08;
+const AVATAR_HEIGHT = 1.65;
+const AVATAR_HEAD_RADIUS = 0.24;
+const AVATAR_BODY_RADIUS = 0.28;
+
+type AvatarSnapshot = ReturnType<typeof useThreeDStore.getState>['avatars'][string];
+
+const createLabelTexture = (text: string, color: string, accent: string): THREE.CanvasTexture => {
+  const canvas = document.createElement('canvas');
+  canvas.width = 512;
+  canvas.height = 256;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return new THREE.CanvasTexture(canvas);
+
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.fillStyle = 'rgba(0,0,0,0)';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  ctx.fillStyle = `${accent}33`;
+  ctx.strokeStyle = accent;
+  ctx.lineWidth = 4;
+  const padding = 32;
+  const radius = 28;
+  const width = canvas.width - padding * 2;
+  const height = canvas.height - padding * 2;
+  ctx.beginPath();
+  ctx.moveTo(padding + radius, padding);
+  ctx.lineTo(padding + width - radius, padding);
+  ctx.quadraticCurveTo(padding + width, padding, padding + width, padding + radius);
+  ctx.lineTo(padding + width, padding + height - radius);
+  ctx.quadraticCurveTo(
+    padding + width,
+    padding + height,
+    padding + width - radius,
+    padding + height,
+  );
+  ctx.lineTo(padding + radius, padding + height);
+  ctx.quadraticCurveTo(padding, padding + height, padding, padding + height - radius);
+  ctx.lineTo(padding, padding + radius);
+  ctx.quadraticCurveTo(padding, padding, padding + radius, padding);
+  ctx.closePath();
+  ctx.fill();
+  ctx.stroke();
+
+  ctx.fillStyle = color;
+  ctx.font = '600 72px "Inter", sans-serif';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(text, canvas.width / 2, canvas.height / 2);
+
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.anisotropy = 4;
+  texture.needsUpdate = true;
+  return texture;
+};
+
+const buildRoomMesh = (
+  room: ReturnType<typeof useThreeDStore.getState>['rooms'][number],
+  tokens: ReturnType<typeof getThemeTokens>,
+): THREE.Group => {
+  const group = new THREE.Group();
+
+  if (room.boundary.type === 'rect') {
+    const geometry = new THREE.BoxGeometry(room.boundary.size[0], FLOOR_HEIGHT, room.boundary.size[1]);
+    const material = new THREE.MeshStandardMaterial({
+      color: new THREE.Color(room.themeColor).lerp(new THREE.Color(tokens.surfaceAlt), 0.35),
+      transparent: true,
+      opacity: 0.85,
+    });
+    const floor = new THREE.Mesh(geometry, material);
+    floor.position.set(room.boundary.center[0], FLOOR_HEIGHT / 2, room.boundary.center[1]);
+    if (room.boundary.rotation) {
+      floor.rotation.y = room.boundary.rotation;
+    }
+    floor.receiveShadow = true;
+    group.add(floor);
+
+    const edges = new THREE.EdgesGeometry(geometry);
+    const edgeMaterial = new THREE.LineBasicMaterial({
+      color: new THREE.Color(room.themeColor).lerp(new THREE.Color(tokens.textMuted), 0.2),
+      linewidth: 1,
+    });
+    const edgeLines = new THREE.LineSegments(edges, edgeMaterial);
+    edgeLines.position.copy(floor.position);
+    if (room.boundary.rotation) {
+      edgeLines.rotation.y = room.boundary.rotation;
+    }
+    group.add(edgeLines);
+  } else if (room.boundary.type === 'circle') {
+    const geometry = new THREE.CylinderGeometry(
+      room.boundary.radius,
+      room.boundary.radius,
+      FLOOR_HEIGHT,
+      48,
+      1,
+      false,
+    );
+    const material = new THREE.MeshStandardMaterial({
+      color: new THREE.Color(room.themeColor).lerp(new THREE.Color(tokens.surfaceAlt), 0.25),
+      transparent: true,
+      opacity: 0.9,
+      side: THREE.DoubleSide,
+    });
+    const floor = new THREE.Mesh(geometry, material);
+    floor.position.set(room.boundary.center[0], FLOOR_HEIGHT / 2, room.boundary.center[1]);
+    floor.receiveShadow = true;
+    group.add(floor);
+
+    const rimGeometry = new THREE.RingGeometry(
+      room.boundary.radius * 0.98,
+      room.boundary.radius,
+      64,
+    );
+    const rimMaterial = new THREE.MeshBasicMaterial({
+      color: new THREE.Color(room.themeColor),
+      side: THREE.DoubleSide,
+    });
+    const rim = new THREE.Mesh(rimGeometry, rimMaterial);
+    rim.rotation.x = -Math.PI / 2;
+    rim.position.set(room.boundary.center[0], FLOOR_HEIGHT + 0.002, room.boundary.center[1]);
+    group.add(rim);
+  }
+
+  const labelTexture = createLabelTexture(room.name, tokens.textPrimary, room.themeColor);
+  const labelMaterial = new THREE.SpriteMaterial({ map: labelTexture, transparent: true });
+  const label = new THREE.Sprite(labelMaterial);
+  label.scale.set(6, 2.4, 1);
+  label.position.set(room.boundary.center[0], FLOOR_HEIGHT + 1.8, room.boundary.center[1]);
+  label.renderOrder = 10;
+  group.add(label);
+
+  group.name = `room:${room.id}`;
+
+  return group;
+};
+
+const buildAvatarMesh = (
+  avatar: AvatarSnapshot,
+  tokens: ReturnType<typeof getThemeTokens>,
+): THREE.Group => {
+  const group = new THREE.Group();
+  group.name = avatar.id;
+
+  const baseColor = avatar.isLocal
+    ? new THREE.Color(tokens.accent)
+    : new THREE.Color(tokens.textSecondary).lerp(new THREE.Color(avatar.avatarUrl ? '#ffffff' : tokens.textPrimary), 0.25);
+
+  const bodyMaterial = new THREE.MeshStandardMaterial({
+    color: baseColor,
+    metalness: 0.1,
+    roughness: 0.45,
+  });
+
+  const bodyGeometry = new THREE.CapsuleGeometry(AVATAR_BODY_RADIUS, AVATAR_HEIGHT - AVATAR_HEAD_RADIUS * 2, 8, 16);
+  const body = new THREE.Mesh(bodyGeometry, bodyMaterial);
+  body.castShadow = true;
+  body.position.y = AVATAR_HEIGHT / 2;
+  group.add(body);
+
+  const headMaterial = new THREE.MeshStandardMaterial({
+    color: avatar.isLocal ? new THREE.Color(tokens.surface) : baseColor.clone().offsetHSL(0, 0, 0.1),
+    metalness: 0.05,
+    roughness: 0.4,
+  });
+  const headGeometry = new THREE.SphereGeometry(AVATAR_HEAD_RADIUS, 32, 16);
+  const head = new THREE.Mesh(headGeometry, headMaterial);
+  head.castShadow = true;
+  head.position.y = AVATAR_HEIGHT + AVATAR_HEAD_RADIUS * 0.6;
+  group.add(head);
+
+  const nameCanvas = document.createElement('canvas');
+  nameCanvas.width = 256;
+  nameCanvas.height = 128;
+  const nameCtx = nameCanvas.getContext('2d');
+  if (nameCtx) {
+    nameCtx.clearRect(0, 0, nameCanvas.width, nameCanvas.height);
+    nameCtx.fillStyle = avatar.isLocal ? tokens.accent : tokens.surface;
+    nameCtx.globalAlpha = 0.92;
+    nameCtx.fillRect(0, 0, nameCanvas.width, nameCanvas.height);
+    nameCtx.globalAlpha = 1;
+    nameCtx.fillStyle = avatar.isLocal ? tokens.surface : tokens.textPrimary;
+    nameCtx.font = '600 42px "Inter", sans-serif';
+    nameCtx.textAlign = 'center';
+    nameCtx.textBaseline = 'middle';
+    nameCtx.fillText(avatar.displayName ?? 'Guest', nameCanvas.width / 2, nameCanvas.height / 2);
+  }
+  const nameTexture = new THREE.CanvasTexture(nameCanvas);
+  nameTexture.anisotropy = 2;
+  const nameMaterial = new THREE.SpriteMaterial({ map: nameTexture, transparent: true });
+  const nameplate = new THREE.Sprite(nameMaterial);
+  nameplate.position.set(0, AVATAR_HEIGHT + AVATAR_HEAD_RADIUS * 2.6, 0);
+  nameplate.scale.set(2.7, 0.9, 1);
+  nameplate.renderOrder = 20;
+  group.add(nameplate);
+
+  group.userData = {
+    bobOffset: Math.random() * Math.PI * 2,
+  };
+
+  return group;
+};
+
+const updateAvatarMesh = (group: THREE.Group, avatar: AvatarSnapshot, now: number): void => {
+  group.position.set(avatar.position.x, 0, avatar.position.y);
+
+  const bob = Math.sin(now * 0.9 + (group.userData?.bobOffset ?? 0)) * 0.08;
+  group.children.forEach((child) => {
+    if (child instanceof THREE.Mesh) {
+      if (child.geometry instanceof THREE.SphereGeometry) {
+        child.position.y = AVATAR_HEIGHT + AVATAR_HEAD_RADIUS * 0.6 + bob;
+      }
+    }
+    if (child instanceof THREE.Sprite && child.renderOrder === 20) {
+      child.position.y = AVATAR_HEIGHT + AVATAR_HEAD_RADIUS * 2.6 + bob;
+    }
+  });
+  group.userData.lastAvatar = avatar;
+};
+
+const ThreeDScene: React.FC = () => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const rendererRef = useRef<THREE.WebGLRenderer>();
+  const sceneRef = useRef<THREE.Scene>();
+  const cameraRef = useRef<THREE.PerspectiveCamera>();
+  const avatarGroupRef = useRef<THREE.Group>();
+  const roomsGroupRef = useRef<THREE.Group>();
+  const clockRef = useRef(new THREE.Clock());
+
+  const theme = useUIStore((state) => state.theme);
+  const tokens = getThemeTokens(theme);
+  const quality = useThreeDStore((state) => state.quality);
+  const rooms = useThreeDStore((state) => state.rooms);
+  const avatars = useThreeDStore((state) => Object.values(state.avatars));
+  const waypoints = useThreeDStore((state) => state.minimapWaypoints);
+
+  const sortedAvatars = useMemo(
+    () =>
+      [...avatars].sort((a, b) => (a.isLocal === b.isLocal ? a.id.localeCompare(b.id) : a.isLocal ? -1 : 1)),
+    [avatars],
+  );
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const pixelRatio = typeof window !== 'undefined' ? window.devicePixelRatio : 1;
+    clockRef.current.start();
+    const renderer = new THREE.WebGLRenderer({ antialias: quality !== 'low', alpha: true });
+    renderer.setPixelRatio(quality === 'high' ? pixelRatio : Math.min(pixelRatio, 1.5));
+    renderer.setSize(containerRef.current.clientWidth, containerRef.current.clientHeight);
+    renderer.shadowMap.enabled = quality !== 'low';
+    renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+    containerRef.current.appendChild(renderer.domElement);
+    rendererRef.current = renderer;
+
+    const scene = new THREE.Scene();
+    sceneRef.current = scene;
+
+    const camera = new THREE.PerspectiveCamera(
+      48,
+      containerRef.current.clientWidth / containerRef.current.clientHeight,
+      0.1,
+      200,
+    );
+    camera.position.set(24, 20, 26);
+    camera.lookAt(new THREE.Vector3(4, 0, 4));
+    cameraRef.current = camera;
+
+    const ambient = new THREE.HemisphereLight(0xffffff, 0x111111, 0.92);
+    scene.add(ambient);
+
+    const directional = new THREE.DirectionalLight(0xffffff, 0.8);
+    directional.name = 'key-light';
+    directional.position.set(20, 30, 16);
+    directional.castShadow = quality !== 'low';
+    directional.shadow.camera.top = 40;
+    directional.shadow.camera.bottom = -40;
+    directional.shadow.camera.left = -40;
+    directional.shadow.camera.right = 40;
+    directional.shadow.mapSize.width = 1024;
+    directional.shadow.mapSize.height = 1024;
+    scene.add(directional);
+
+    const groundGeometry = new THREE.PlaneGeometry(120, 120, 1, 1);
+    const groundMaterial = new THREE.MeshStandardMaterial({
+      color: new THREE.Color(tokens.background).lerp(new THREE.Color(tokens.surfaceAlt), 0.2),
+      roughness: 0.9,
+      metalness: 0.05,
+    });
+    const ground = new THREE.Mesh(groundGeometry, groundMaterial);
+    ground.receiveShadow = true;
+    ground.rotation.x = -Math.PI / 2;
+    scene.add(ground);
+
+    const roomsGroup = new THREE.Group();
+    roomsGroupRef.current = roomsGroup;
+    scene.add(roomsGroup);
+
+    const avatarGroup = new THREE.Group();
+    avatarGroupRef.current = avatarGroup;
+    scene.add(avatarGroup);
+
+    const waypointGroup = new THREE.Group();
+    waypointGroup.name = 'waypoints';
+    scene.add(waypointGroup);
+
+    const resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.target !== containerRef.current) continue;
+        const { width, height } = entry.contentRect;
+        renderer.setSize(width, height);
+        camera.aspect = width / height;
+        camera.updateProjectionMatrix();
+      }
+    });
+    resizeObserver.observe(containerRef.current);
+
+    let frameId: number;
+    const renderLoop = () => {
+      const elapsed = clockRef.current.getElapsedTime();
+      avatarGroup.children.forEach((child) => {
+        if (child instanceof THREE.Group) {
+          const snapshot = child.userData?.lastAvatar as AvatarSnapshot | undefined;
+          if (snapshot) {
+            updateAvatarMesh(child, snapshot, elapsed);
+          }
+        }
+      });
+
+      renderer.render(scene, camera);
+      frameId = requestAnimationFrame(renderLoop);
+    };
+    frameId = requestAnimationFrame(renderLoop);
+
+    return () => {
+      cancelAnimationFrame(frameId);
+      resizeObserver.disconnect();
+      renderer.dispose();
+      containerRef.current?.removeChild(renderer.domElement);
+      rendererRef.current = undefined;
+      sceneRef.current = undefined;
+      cameraRef.current = undefined;
+      avatarGroupRef.current = undefined;
+      roomsGroupRef.current = undefined;
+    };
+  }, []);
+
+  useEffect(() => {
+    const scene = sceneRef.current;
+    if (!scene) return;
+
+    scene.background = new THREE.Color(tokens.background).lerp(
+      new THREE.Color(theme === 'dark' ? '#080912' : '#f1f5ff'),
+      0.35,
+    );
+    scene.fog = new THREE.Fog(scene.background.getHex(), 40, 120);
+
+    const ground = scene.children.find((child) => child instanceof THREE.Mesh && child.geometry instanceof THREE.PlaneGeometry) as
+      | THREE.Mesh
+      | undefined;
+    if (ground) {
+      (ground.material as THREE.MeshStandardMaterial).color = new THREE.Color(tokens.background).lerp(
+        new THREE.Color(tokens.surfaceAlt),
+        0.2,
+      );
+    }
+  }, [tokens, theme]);
+
+  useEffect(() => {
+    const renderer = rendererRef.current;
+    if (renderer) {
+      const pixelRatio = typeof window !== 'undefined' ? window.devicePixelRatio : 1;
+      renderer.shadowMap.enabled = quality !== 'low';
+      renderer.setPixelRatio(quality === 'high' ? pixelRatio : Math.min(pixelRatio, 1.5));
+    }
+
+    const scene = sceneRef.current;
+    const keyLight = scene?.getObjectByName('key-light') as THREE.DirectionalLight | undefined;
+    if (keyLight) {
+      keyLight.castShadow = quality !== 'low';
+      keyLight.intensity = quality === 'low' ? 0.65 : 0.85;
+    }
+  }, [quality]);
+
+  useEffect(() => {
+    const roomsGroup = roomsGroupRef.current;
+    const scene = sceneRef.current;
+    if (!roomsGroup || !scene) return;
+
+    while (roomsGroup.children.length) {
+      const child = roomsGroup.children.pop();
+      if (child) {
+        child.traverse((node) => {
+          if (node instanceof THREE.Sprite) {
+            (node.material as THREE.SpriteMaterial).map?.dispose();
+            node.material.dispose();
+          }
+          if (node instanceof THREE.Mesh) {
+            node.geometry.dispose();
+            if (Array.isArray(node.material)) {
+              node.material.forEach((material) => material.dispose());
+            } else {
+              node.material.dispose();
+            }
+          }
+          if (node instanceof THREE.LineSegments) {
+            node.geometry.dispose();
+            if (Array.isArray(node.material)) {
+              node.material.forEach((material) => material.dispose());
+            } else {
+              node.material.dispose();
+            }
+          }
+        });
+      }
+    }
+
+    rooms.forEach((room) => {
+      const mesh = buildRoomMesh(room, tokens);
+      roomsGroup.add(mesh);
+    });
+  }, [rooms, tokens]);
+
+  useEffect(() => {
+    const avatarGroup = avatarGroupRef.current;
+    if (!avatarGroup) return;
+
+    const now = clockRef.current.getElapsedTime();
+    const existingIds = new Set(sortedAvatars.map((avatar) => avatar.id));
+
+    avatarGroup.children.slice().forEach((child) => {
+      if (!(child instanceof THREE.Group)) return;
+      if (!existingIds.has(child.name)) {
+        avatarGroup.remove(child);
+        child.traverse((node) => {
+          if (node instanceof THREE.Mesh) {
+            node.geometry.dispose();
+            if (Array.isArray(node.material)) {
+              node.material.forEach((material) => material.dispose());
+            } else {
+              node.material.dispose();
+            }
+          }
+          if (node instanceof THREE.Sprite) {
+            (node.material as THREE.SpriteMaterial).map?.dispose();
+            node.material.dispose();
+          }
+        });
+      }
+    });
+
+    sortedAvatars.forEach((avatar) => {
+      let avatarMesh = avatarGroup.getObjectByName(avatar.id) as THREE.Group | null;
+      if (!avatarMesh) {
+        avatarMesh = buildAvatarMesh(avatar, tokens);
+        avatarGroup.add(avatarMesh);
+      }
+      updateAvatarMesh(avatarMesh, avatar, now);
+    });
+  }, [sortedAvatars, tokens]);
+
+  useEffect(() => {
+    const scene = sceneRef.current;
+    if (!scene) return;
+    const waypointGroup = scene.getObjectByName('waypoints') as THREE.Group | undefined;
+    if (!waypointGroup) return;
+
+    while (waypointGroup.children.length) {
+      const child = waypointGroup.children.pop();
+      if (child) {
+        child.traverse((node) => {
+          if (node instanceof THREE.Mesh) {
+            node.geometry.dispose();
+            if (!Array.isArray(node.material)) {
+              node.material.dispose();
+            }
+          }
+        });
+      }
+    }
+
+    Object.entries(waypoints).forEach(([avatarId, waypoint]) => {
+      if (!waypoint) return;
+      const material = new THREE.MeshBasicMaterial({ color: tokens.accent, transparent: true, opacity: 0.7 });
+      const geometry = new THREE.ConeGeometry(0.45, 1.1, 16);
+      const cone = new THREE.Mesh(geometry, material);
+      cone.position.set(waypoint.x, 0.55, waypoint.y);
+      cone.rotation.x = Math.PI;
+      cone.name = `waypoint:${avatarId}`;
+      waypointGroup.add(cone);
+    });
+  }, [tokens, waypoints]);
+
+  return <div ref={containerRef} className="absolute inset-0" />;
+};
+
+export default ThreeDScene;

--- a/nexspace-frontend/src/features/threeDMode/config/rooms.ts
+++ b/nexspace-frontend/src/features/threeDMode/config/rooms.ts
@@ -1,0 +1,76 @@
+export type RoomBoundary =
+  | { type: 'rect'; center: [number, number]; size: [number, number]; rotation?: number }
+  | { type: 'circle'; center: [number, number]; radius: number };
+
+export type AudioProfile = {
+  falloff: 'linear' | 'logarithmic';
+  minDistance: number;
+  maxDistance: number;
+  roomIsolation: number; // 0-1, 1 = fully isolated
+};
+
+export type RoomDefinition = {
+  id: string;
+  name: string;
+  description?: string;
+  themeColor: string;
+  boundary: RoomBoundary;
+  audio: AudioProfile;
+  capacityHint?: number;
+  signage?: string;
+};
+
+export const defaultRooms: RoomDefinition[] = [
+  {
+    id: 'open-work-area',
+    name: 'Open Work Area',
+    description: 'Collaborative desks with ambient spatial audio.',
+    themeColor: '#5B8DFF',
+    capacityHint: 25,
+    boundary: { type: 'rect', center: [0, 0], size: [18, 14] },
+    audio: { falloff: 'linear', minDistance: 1.5, maxDistance: 10, roomIsolation: 0.4 },
+    signage: 'Heads-down focus, quick stand-ups welcome.',
+  },
+  {
+    id: 'game-room',
+    name: 'Game Room',
+    description: 'Casual breakout tables for play & reset.',
+    themeColor: '#FF8DA1',
+    capacityHint: 10,
+    boundary: { type: 'rect', center: [18, 6], size: [10, 8] },
+    audio: { falloff: 'linear', minDistance: 1.2, maxDistance: 6, roomIsolation: 0.65 },
+    signage: 'Launch a quick game and relax with teammates.',
+  },
+  {
+    id: 'lounge-zone',
+    name: 'Lounge / Coffee',
+    description: 'Soft seating, serendipitous chats, casual syncs.',
+    themeColor: '#F6C65B',
+    capacityHint: 12,
+    boundary: { type: 'circle', center: [6, -12], radius: 5 },
+    audio: { falloff: 'linear', minDistance: 1.4, maxDistance: 7, roomIsolation: 0.55 },
+    signage: 'Refill your mug and unwind together.',
+  },
+  {
+    id: 'conference-room',
+    name: 'Conference Room',
+    description: 'Formal meetings, screen shares, and huddles.',
+    themeColor: '#7AE582',
+    capacityHint: 12,
+    boundary: { type: 'rect', center: [-14, 8], size: [8, 10] },
+    audio: { falloff: 'logarithmic', minDistance: 1.2, maxDistance: 4.5, roomIsolation: 0.85 },
+    signage: 'Reserve for deep discussions and hybrid calls.',
+  },
+  {
+    id: 'event-hall',
+    name: 'Event Hall',
+    description: 'Spotlight talks, all-hands, community events.',
+    themeColor: '#A680FF',
+    capacityHint: 50,
+    boundary: { type: 'rect', center: [-4, 18], size: [20, 12] },
+    audio: { falloff: 'logarithmic', minDistance: 2.5, maxDistance: 14, roomIsolation: 0.9 },
+    signage: 'Presenters up front, audience anywhere in the hall.',
+  },
+];
+
+export const fallbackRoomId = defaultRooms[0]?.id ?? 'open-work-area';

--- a/nexspace-frontend/src/features/threeDMode/hooks/useSpatialAudioRouting.ts
+++ b/nexspace-frontend/src/features/threeDMode/hooks/useSpatialAudioRouting.ts
@@ -1,0 +1,130 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { RoomEvent, type RemoteParticipant, type RemoteTrackPublication } from 'livekit-client';
+import { useMeetingStore } from '../../../stores/meetingStore';
+import { useThreeDStore } from '../store/threeDStore';
+
+const MIN_VOLUME = 0.02;
+
+const computeDistance = (a: { x: number; y: number }, b: { x: number; y: number }): number => {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  return Math.sqrt(dx * dx + dy * dy);
+};
+
+const computeFalloff = (
+  distance: number,
+  minDistance: number,
+  maxDistance: number,
+  mode: 'linear' | 'logarithmic',
+): number => {
+  if (distance <= minDistance) return 1;
+  if (distance >= maxDistance) return 0;
+  const t = (distance - minDistance) / Math.max(0.0001, maxDistance - minDistance);
+  if (mode === 'logarithmic') {
+    return Math.pow(1 - t, 2.2);
+  }
+  return 1 - t;
+};
+
+const setPublicationVolume = (publication: RemoteTrackPublication, volume: number, cache: Map<string, number>) => {
+  const track = publication.audioTrack;
+  if (!track) return;
+  const key = publication.trackSid ?? publication.sid ?? `${publication.participant?.sid ?? ''}:${publication.source}`;
+  const previous = cache.get(key);
+  if (previous !== undefined && Math.abs(previous - volume) < 0.01) {
+    return;
+  }
+  cache.set(key, volume);
+  try {
+    track.setVolume(volume);
+  } catch {
+    // Ignore errors from LiveKit when tracks are not ready yet
+  }
+};
+
+export const useSpatialAudioRouting = (): void => {
+  const room = useMeetingStore((s) => s.room);
+  const speakerEnabled = useMeetingStore((s) => s.speakerEnabled);
+  const localAvatarId = useThreeDStore((s) => s.localAvatarId);
+  const rooms = useThreeDStore((s) => s.rooms);
+
+  const cacheRef = useRef<Map<string, number>>(new Map());
+
+  const roomById = useMemo(() => {
+    const map = new Map<string, typeof rooms[number]>();
+    rooms.forEach((roomDef) => map.set(roomDef.id, roomDef));
+    return map;
+  }, [rooms]);
+
+  useEffect(() => {
+    if (!room) return;
+
+    const updateVolumes = () => {
+      const state = useThreeDStore.getState();
+      if (!localAvatarId) return;
+      const local = state.avatars[localAvatarId];
+      if (!local) return;
+
+      const localRoom = roomById.get(local.roomId);
+
+      const participants = Array.from(room.remoteParticipants.values()) as RemoteParticipant[];
+      participants.forEach((participant) => {
+        const remoteId = participant.sid ?? participant.identity;
+        const avatar = state.avatars[remoteId];
+        if (!avatar) return;
+
+        const remoteRoom = roomById.get(avatar.roomId);
+        const distance = computeDistance(local.position, avatar.position);
+        const profile = remoteRoom?.audio ?? localRoom?.audio;
+        const minDistance = profile?.minDistance ?? 1.5;
+        const maxDistance = profile?.maxDistance ?? 10;
+        const falloff = computeFalloff(distance, minDistance, maxDistance, profile?.falloff ?? 'linear');
+        const isolationFactor = remoteRoom?.id === local.roomId
+          ? 1
+          : Math.max(0, 1 - Math.max(remoteRoom?.audio.roomIsolation ?? 0, localRoom?.audio.roomIsolation ?? 0));
+
+        let baseVolume = speakerEnabled ? falloff * isolationFactor : 0;
+        if (baseVolume > 0) {
+          baseVolume = Math.max(baseVolume, MIN_VOLUME);
+        }
+
+        const publications = typeof participant.getTrackPublications === 'function'
+          ? participant.getTrackPublications()
+          : Array.from(participant.trackPublications?.values?.() ?? []);
+
+        publications.forEach((publication) => {
+          if (publication.kind !== 'audio') return;
+          setPublicationVolume(publication, baseVolume, cacheRef.current);
+        });
+      });
+    };
+
+    updateVolumes();
+
+    const unsubAvatars = useThreeDStore.subscribe(
+      (s) => s.avatars,
+      () => updateVolumes(),
+    );
+    const unsubRooms = useThreeDStore.subscribe(
+      (s) => s.rooms,
+      () => updateVolumes(),
+    );
+
+    const handleTrack = () => updateVolumes();
+    room.on(RoomEvent.TrackSubscribed, handleTrack);
+    room.on(RoomEvent.TrackUnsubscribed, handleTrack);
+    room.on(RoomEvent.RemoteTrackPublished, handleTrack);
+
+    return () => {
+      unsubAvatars();
+      unsubRooms();
+      room.off(RoomEvent.TrackSubscribed, handleTrack);
+      room.off(RoomEvent.TrackUnsubscribed, handleTrack);
+      room.off(RoomEvent.RemoteTrackPublished, handleTrack);
+    };
+  }, [room, localAvatarId, roomById, speakerEnabled]);
+
+  useEffect(() => {
+    cacheRef.current.clear();
+  }, [localAvatarId, roomById, speakerEnabled]);
+};

--- a/nexspace-frontend/src/features/threeDMode/hooks/useThreeDAvatarSync.ts
+++ b/nexspace-frontend/src/features/threeDMode/hooks/useThreeDAvatarSync.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useMeetingStore } from '../../../stores/meetingStore';
 import { useThreeDStore } from '../store/threeDStore';
 import { fallbackRoomId } from '../config/rooms';
@@ -7,40 +7,83 @@ export const useThreeDAvatarSync = (): void => {
   const participants = useMeetingStore((s) => s.participants);
   const presenceById = useMeetingStore((s) => s.presenceById);
   const localPresence = useMeetingStore((s) => s.localPresence);
+  const localParticipantId = useMeetingStore(
+    (s) => s.room?.localParticipant?.sid ?? s.room?.localParticipant?.identity ?? null,
+  );
 
   const setLocalAvatarId = useThreeDStore((s) => s.setLocalAvatarId);
   const upsertAvatar = useThreeDStore((s) => s.upsertAvatar);
   const removeAvatar = useThreeDStore((s) => s.removeAvatar);
   const rooms = useThreeDStore((s) => s.rooms);
 
+  const lastSnapshotRef = useRef<string | null>(null);
+
   useEffect(() => {
     const fallback = rooms[0]?.id ?? fallbackRoomId;
-    const seen = new Set<string>();
-    const existing = useThreeDStore.getState().avatars;
 
-    participants.forEach((participant, index) => {
-      if (!participant?.id) return;
-      const isLocal = index === 0;
-      if (isLocal) setLocalAvatarId(participant.id);
+    const normalized = participants.map((participant, index) => {
+      const { id } = participant;
+      const derivedLocal = localParticipantId ? id === localParticipantId : index === 0;
+      const presenceRecord = presenceById[id];
+      const status = presenceRecord?.status ?? (derivedLocal ? localPresence : undefined);
 
-      const presenceRecord = presenceById[participant.id];
-      const status = presenceRecord?.status ?? (isLocal ? localPresence : undefined);
-      const previous = existing[participant.id];
-
-      upsertAvatar({
-        id: participant.id,
+      return {
+        id,
         displayName: participant.name ?? participant.email ?? 'Guest',
         avatarUrl: participant.avatar,
-        roomId: previous?.roomId ?? fallback,
         status,
-        isLocal,
-      });
+        isLocal: derivedLocal,
+      };
+    });
 
+    const signature = JSON.stringify({
+      participants: normalized.map((entry) => ({
+        id: entry.id,
+        displayName: entry.displayName,
+        avatarUrl: entry.avatarUrl ?? null,
+        status: entry.status ?? null,
+        isLocal: entry.isLocal,
+      })),
+      rooms: rooms.map((room) => room.id),
+    });
+
+    if (lastSnapshotRef.current === signature) {
+      return;
+    }
+    lastSnapshotRef.current = signature;
+
+    const existing = useThreeDStore.getState().avatars;
+    const seen = new Set<string>();
+
+    const resolvedLocalId = normalized.find((entry) => entry.isLocal)?.id ?? normalized[0]?.id ?? null;
+    setLocalAvatarId(resolvedLocalId ?? null);
+
+    normalized.forEach((participant) => {
+      const previous = existing[participant.id];
+      upsertAvatar({
+        id: participant.id,
+        displayName: participant.displayName,
+        avatarUrl: participant.avatarUrl,
+        roomId: previous?.roomId ?? fallback,
+        status: participant.status,
+        isLocal: participant.isLocal,
+      });
       seen.add(participant.id);
     });
 
     Object.keys(existing).forEach((id) => {
-      if (!seen.has(id)) removeAvatar(id);
+      if (!seen.has(id)) {
+        removeAvatar(id);
+      }
     });
-  }, [participants, presenceById, localPresence, setLocalAvatarId, upsertAvatar, removeAvatar, rooms]);
+  }, [
+    participants,
+    presenceById,
+    localPresence,
+    localParticipantId,
+    rooms,
+    setLocalAvatarId,
+    upsertAvatar,
+    removeAvatar,
+  ]);
 };

--- a/nexspace-frontend/src/features/threeDMode/hooks/useThreeDAvatarSync.ts
+++ b/nexspace-frontend/src/features/threeDMode/hooks/useThreeDAvatarSync.ts
@@ -1,0 +1,45 @@
+import { useEffect } from 'react';
+import { useMeetingStore } from '../../../stores/meetingStore';
+import { useThreeDStore } from '../store/threeDStore';
+import { fallbackRoomId } from '../config/rooms';
+
+export const useThreeDAvatarSync = (): void => {
+  const participants = useMeetingStore((s) => s.participants);
+  const presenceById = useMeetingStore((s) => s.presenceById);
+  const localPresence = useMeetingStore((s) => s.localPresence);
+
+  const setLocalAvatarId = useThreeDStore((s) => s.setLocalAvatarId);
+  const upsertAvatar = useThreeDStore((s) => s.upsertAvatar);
+  const removeAvatar = useThreeDStore((s) => s.removeAvatar);
+  const rooms = useThreeDStore((s) => s.rooms);
+
+  useEffect(() => {
+    const fallback = rooms[0]?.id ?? fallbackRoomId;
+    const seen = new Set<string>();
+
+    participants.forEach((participant, index) => {
+      if (!participant?.id) return;
+      const isLocal = index === 0;
+      if (isLocal) setLocalAvatarId(participant.id);
+
+      const presenceRecord = presenceById[participant.id];
+      const status = presenceRecord?.status ?? (isLocal ? localPresence : undefined);
+
+      upsertAvatar({
+        id: participant.id,
+        displayName: participant.name ?? participant.email ?? 'Guest',
+        avatarUrl: participant.avatar,
+        roomId: fallback,
+        status,
+        isLocal,
+      });
+
+      seen.add(participant.id);
+    });
+
+    const existing = useThreeDStore.getState().avatars;
+    Object.keys(existing).forEach((id) => {
+      if (!seen.has(id)) removeAvatar(id);
+    });
+  }, [participants, presenceById, localPresence, setLocalAvatarId, upsertAvatar, removeAvatar, rooms]);
+};

--- a/nexspace-frontend/src/features/threeDMode/hooks/useThreeDAvatarSync.ts
+++ b/nexspace-frontend/src/features/threeDMode/hooks/useThreeDAvatarSync.ts
@@ -16,6 +16,7 @@ export const useThreeDAvatarSync = (): void => {
   useEffect(() => {
     const fallback = rooms[0]?.id ?? fallbackRoomId;
     const seen = new Set<string>();
+    const existing = useThreeDStore.getState().avatars;
 
     participants.forEach((participant, index) => {
       if (!participant?.id) return;
@@ -24,12 +25,13 @@ export const useThreeDAvatarSync = (): void => {
 
       const presenceRecord = presenceById[participant.id];
       const status = presenceRecord?.status ?? (isLocal ? localPresence : undefined);
+      const previous = existing[participant.id];
 
       upsertAvatar({
         id: participant.id,
         displayName: participant.name ?? participant.email ?? 'Guest',
         avatarUrl: participant.avatar,
-        roomId: fallback,
+        roomId: previous?.roomId ?? fallback,
         status,
         isLocal,
       });
@@ -37,7 +39,6 @@ export const useThreeDAvatarSync = (): void => {
       seen.add(participant.id);
     });
 
-    const existing = useThreeDStore.getState().avatars;
     Object.keys(existing).forEach((id) => {
       if (!seen.has(id)) removeAvatar(id);
     });

--- a/nexspace-frontend/src/features/threeDMode/hooks/useThreeDMovement.ts
+++ b/nexspace-frontend/src/features/threeDMode/hooks/useThreeDMovement.ts
@@ -1,0 +1,103 @@
+import { useEffect, useRef } from 'react';
+import { useThreeDStore } from '../store/threeDStore';
+
+const MOVEMENT_SPEED = 3.6; // units per second
+const ACCELERATION = 12;
+const DAMPING = 8;
+
+const KEY_TO_VECTOR: Record<string, { x: number; y: number }> = {
+  KeyW: { x: 0, y: -1 },
+  ArrowUp: { x: 0, y: -1 },
+  KeyS: { x: 0, y: 1 },
+  ArrowDown: { x: 0, y: 1 },
+  KeyA: { x: -1, y: 0 },
+  ArrowLeft: { x: -1, y: 0 },
+  KeyD: { x: 1, y: 0 },
+  ArrowRight: { x: 1, y: 0 },
+};
+
+export const useThreeDMovement = (): void => {
+  const localAvatarId = useThreeDStore((s) => s.localAvatarId);
+  const setAvatarPosition = useThreeDStore((s) => s.setAvatarPosition);
+
+  const pressedKeysRef = useRef<Set<string>>(new Set());
+  const velocityRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
+  const lastFrameRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!localAvatarId) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (KEY_TO_VECTOR[event.code]) {
+        pressedKeysRef.current.add(event.code);
+      }
+    };
+
+    const handleKeyUp = (event: KeyboardEvent) => {
+      if (KEY_TO_VECTOR[event.code]) {
+        pressedKeysRef.current.delete(event.code);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('keyup', handleKeyUp);
+
+    let animationFrame: number;
+
+    const step = (time: number) => {
+      if (!localAvatarId) return;
+      const store = useThreeDStore.getState();
+      const avatar = store.avatars[localAvatarId];
+      if (!avatar) {
+        animationFrame = requestAnimationFrame(step);
+        return;
+      }
+
+      const last = lastFrameRef.current ?? time;
+      const delta = Math.min((time - last) / 1000, 1 / 24);
+      lastFrameRef.current = time;
+
+      let inputX = 0;
+      let inputY = 0;
+      pressedKeysRef.current.forEach((code) => {
+        const vector = KEY_TO_VECTOR[code];
+        if (vector) {
+          inputX += vector.x;
+          inputY += vector.y;
+        }
+      });
+
+      if (inputX !== 0 || inputY !== 0) {
+        const length = Math.hypot(inputX, inputY) || 1;
+        inputX /= length;
+        inputY /= length;
+
+        velocityRef.current.x = velocityRef.current.x + (inputX * MOVEMENT_SPEED - velocityRef.current.x) * Math.min(1, ACCELERATION * delta);
+        velocityRef.current.y = velocityRef.current.y + (inputY * MOVEMENT_SPEED - velocityRef.current.y) * Math.min(1, ACCELERATION * delta);
+      } else {
+        velocityRef.current.x = velocityRef.current.x * Math.max(0, 1 - DAMPING * delta);
+        velocityRef.current.y = velocityRef.current.y * Math.max(0, 1 - DAMPING * delta);
+      }
+
+      const nextX = avatar.position.x + velocityRef.current.x * delta;
+      const nextY = avatar.position.y + velocityRef.current.y * delta;
+
+      if (Number.isFinite(nextX) && Number.isFinite(nextY)) {
+        setAvatarPosition(localAvatarId, { x: nextX, y: nextY });
+      }
+
+      animationFrame = requestAnimationFrame(step);
+    };
+
+    animationFrame = requestAnimationFrame(step);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('keyup', handleKeyUp);
+      if (animationFrame) cancelAnimationFrame(animationFrame);
+      pressedKeysRef.current.clear();
+      velocityRef.current = { x: 0, y: 0 };
+      lastFrameRef.current = null;
+    };
+  }, [localAvatarId, setAvatarPosition]);
+};

--- a/nexspace-frontend/src/features/threeDMode/index.ts
+++ b/nexspace-frontend/src/features/threeDMode/index.ts
@@ -1,0 +1,3 @@
+export { default as ThreeDExperience } from './components/ThreeDExperience';
+export * from './store/threeDStore';
+export * from './config/rooms';

--- a/nexspace-frontend/src/features/threeDMode/store/threeDStore.ts
+++ b/nexspace-frontend/src/features/threeDMode/store/threeDStore.ts
@@ -1,0 +1,173 @@
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+import type { PresenceStatus } from '../../../constants/enums';
+import { defaultRooms, fallbackRoomId, type RoomDefinition } from '../config/rooms';
+
+export type Vector2 = { x: number; y: number };
+export type QualityLevel = 'low' | 'medium' | 'high';
+
+export type AvatarRuntimeState = {
+  id: string;
+  displayName: string;
+  roomId: string;
+  position: Vector2;
+  status?: PresenceStatus;
+  isLocal: boolean;
+  avatarUrl?: string;
+  lastActiveTs: number;
+};
+
+export type JoinNudge = {
+  id: string;
+  avatarId: string;
+  roomId: string;
+  displayName: string;
+  timestamp: number;
+};
+
+type PartialAvatarInput = {
+  id: string;
+  displayName?: string;
+  roomId?: string | null;
+  position?: Vector2;
+  status?: PresenceStatus;
+  isLocal?: boolean;
+  avatarUrl?: string;
+};
+
+type ThreeDState = {
+  rooms: RoomDefinition[];
+  localAvatarId: string | null;
+  avatars: Record<string, AvatarRuntimeState>;
+  minimapWaypoints: Record<string, Vector2 | null>;
+  quality: QualityLevel;
+  joinNudges: JoinNudge[];
+  lastNudgeByAvatar: Record<string, number>;
+  joinNudgeCooldownMs: number;
+  setRooms: (rooms: RoomDefinition[]) => void;
+  setLocalAvatarId: (id: string | null) => void;
+  upsertAvatar: (input: PartialAvatarInput) => void;
+  removeAvatar: (id: string) => void;
+  markWaypoint: (avatarId: string, waypoint: Vector2 | null) => void;
+  popJoinNudge: () => JoinNudge | null;
+  clearJoinNudges: () => void;
+  setQuality: (quality: QualityLevel) => void;
+  getOccupantsForRoom: (roomId: string) => AvatarRuntimeState[];
+};
+
+const FALLBACK_POSITION: Vector2 = { x: 0, y: 0 };
+
+export const useThreeDStore = create<ThreeDState>()(
+  devtools((set, get) => ({
+    rooms: defaultRooms,
+    localAvatarId: null,
+    avatars: {},
+    minimapWaypoints: {},
+    quality: 'medium',
+    joinNudges: [],
+    lastNudgeByAvatar: {},
+    joinNudgeCooldownMs: 45_000,
+
+    setRooms: (rooms) => set({ rooms }),
+
+    setLocalAvatarId: (id) => set({ localAvatarId: id }),
+
+    setQuality: (quality) => set({ quality }),
+
+    markWaypoint: (avatarId, waypoint) =>
+      set((state) => ({
+        minimapWaypoints: { ...state.minimapWaypoints, [avatarId]: waypoint },
+      })),
+
+    popJoinNudge: () => {
+      const queue = get().joinNudges;
+      if (!queue.length) return null;
+      const [first, ...rest] = queue;
+      set({ joinNudges: rest });
+      return first;
+    },
+
+    clearJoinNudges: () => set({ joinNudges: [] }),
+
+    removeAvatar: (id) =>
+      set((state) => {
+        if (!state.avatars[id]) return state;
+        const nextAvatars = { ...state.avatars };
+        delete nextAvatars[id];
+        const nextWaypoints = { ...state.minimapWaypoints };
+        delete nextWaypoints[id];
+        const nextLastNudge = { ...state.lastNudgeByAvatar };
+        delete nextLastNudge[id];
+        return {
+          avatars: nextAvatars,
+          minimapWaypoints: nextWaypoints,
+          lastNudgeByAvatar: nextLastNudge,
+        };
+      }),
+
+    upsertAvatar: (input) =>
+      set((state) => {
+        if (!input.id) return state;
+        const previous = state.avatars[input.id];
+        const resolvedRoomId = input.roomId ?? previous?.roomId ?? fallbackRoomId;
+        const resolvedPosition = input.position ?? previous?.position ?? FALLBACK_POSITION;
+        const resolvedDisplayName = input.displayName ?? previous?.displayName ?? 'Participant';
+        const resolvedStatus = input.status ?? previous?.status;
+        const resolvedAvatarUrl = input.avatarUrl ?? previous?.avatarUrl;
+        const resolvedIsLocal = input.isLocal ?? previous?.isLocal ?? false;
+
+        const updated: AvatarRuntimeState = {
+          id: input.id,
+          roomId: resolvedRoomId,
+          position: resolvedPosition,
+          displayName: resolvedDisplayName,
+          status: resolvedStatus,
+          avatarUrl: resolvedAvatarUrl,
+          isLocal: resolvedIsLocal,
+          lastActiveTs: Date.now(),
+        };
+
+        let joinNudges = state.joinNudges;
+        let lastNudgeByAvatar = state.lastNudgeByAvatar;
+
+        const localId = state.localAvatarId ?? (resolvedIsLocal ? input.id : null);
+        const localAvatar = localId
+          ? input.id === localId
+            ? updated
+            : state.avatars[localId]
+          : undefined;
+
+        const roomChanged = previous?.roomId !== updated.roomId;
+        const joinedLocalRoom =
+          roomChanged && !updated.isLocal && localAvatar?.roomId === updated.roomId;
+
+        if (joinedLocalRoom) {
+          const now = Date.now();
+          const lastNudgeAt = state.lastNudgeByAvatar[input.id] ?? 0;
+          if (now - lastNudgeAt >= state.joinNudgeCooldownMs) {
+            const nudge: JoinNudge = {
+              id: `${input.id}:${now}`,
+              avatarId: input.id,
+              roomId: updated.roomId,
+              displayName: resolvedDisplayName,
+              timestamp: now,
+            };
+            joinNudges = [...state.joinNudges, nudge];
+            lastNudgeByAvatar = { ...state.lastNudgeByAvatar, [input.id]: now };
+          }
+        }
+
+        return {
+          avatars: { ...state.avatars, [input.id]: updated },
+          localAvatarId: localId,
+          joinNudges,
+          lastNudgeByAvatar,
+        };
+      }),
+
+    getOccupantsForRoom: (roomId) => {
+      const avatars = get().avatars;
+      return Object.values(avatars).filter((avatar) => avatar.roomId === roomId);
+    },
+  }))
+);

--- a/nexspace-frontend/src/features/threeDMode/store/threeDStore.ts
+++ b/nexspace-frontend/src/features/threeDMode/store/threeDStore.ts
@@ -203,6 +203,25 @@ export const useThreeDStore = create<ThreeDState>()(
         const resolvedAvatarUrl = input.avatarUrl ?? previous?.avatarUrl;
         const resolvedIsLocal = input.isLocal ?? previous?.isLocal ?? false;
 
+        let joinNudges = state.joinNudges;
+        let lastNudgeByAvatar = state.lastNudgeByAvatar;
+
+        const localId = state.localAvatarId ?? (resolvedIsLocal ? input.id : null);
+
+        const noChange =
+          !!previous &&
+          previous.roomId === resolvedRoomId &&
+          previous.displayName === resolvedDisplayName &&
+          previous.status === resolvedStatus &&
+          previous.avatarUrl === resolvedAvatarUrl &&
+          previous.isLocal === resolvedIsLocal &&
+          positionsEqual(previous.position, resolvedPosition) &&
+          state.localAvatarId === localId;
+
+        if (noChange) {
+          return state;
+        }
+
         const updated: AvatarRuntimeState = {
           id: input.id,
           roomId: resolvedRoomId,
@@ -213,11 +232,6 @@ export const useThreeDStore = create<ThreeDState>()(
           isLocal: resolvedIsLocal,
           lastActiveTs: Date.now(),
         };
-
-        let joinNudges = state.joinNudges;
-        let lastNudgeByAvatar = state.lastNudgeByAvatar;
-
-        const localId = state.localAvatarId ?? (resolvedIsLocal ? input.id : null);
         const localAvatar = localId
           ? input.id === localId
             ? updated

--- a/nexspace-frontend/src/features/threeDMode/utils/layout.ts
+++ b/nexspace-frontend/src/features/threeDMode/utils/layout.ts
@@ -1,0 +1,105 @@
+import type { RoomDefinition } from '../config/rooms';
+import type { AvatarRuntimeState, Vector2 } from '../store/threeDStore';
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(Math.max(value, min), max);
+
+const layoutRectangularRoom = (
+  room: RoomDefinition,
+  occupants: AvatarRuntimeState[],
+): Record<string, Vector2> => {
+  if (occupants.length === 0 || room.boundary.type !== 'rect') {
+    return {};
+  }
+
+  const { center, size } = room.boundary;
+  const [width, depth] = size;
+  const [centerX, centerY] = center;
+
+  const columns = clamp(Math.ceil(Math.sqrt(occupants.length)), 1, Math.max(1, occupants.length));
+  const rows = Math.ceil(occupants.length / columns);
+
+  const spacingX = width / (columns + 1);
+  const spacingY = depth / (rows + 1);
+
+  return occupants.reduce<Record<string, Vector2>>((acc, avatar, index) => {
+    const row = Math.floor(index / columns);
+    const column = index % columns;
+
+    const x = centerX - width / 2 + spacingX * (column + 1);
+    const y = centerY - depth / 2 + spacingY * (row + 1);
+
+    acc[avatar.id] = { x, y };
+    return acc;
+  }, {});
+};
+
+const layoutCircularRoom = (
+  room: RoomDefinition,
+  occupants: AvatarRuntimeState[],
+): Record<string, Vector2> => {
+  if (occupants.length === 0 || room.boundary.type !== 'circle') {
+    return {};
+  }
+
+  const { center, radius } = room.boundary;
+  const [centerX, centerY] = center;
+
+  if (occupants.length === 1) {
+    return { [occupants[0].id]: { x: centerX, y: centerY } };
+  }
+
+  const interiorRadius = Math.max(1.5, radius * 0.65);
+
+  return occupants.reduce<Record<string, Vector2>>((acc, avatar, index) => {
+    const angle = (index / occupants.length) * Math.PI * 2;
+    const x = centerX + interiorRadius * Math.cos(angle);
+    const y = centerY + interiorRadius * Math.sin(angle);
+
+    acc[avatar.id] = { x, y };
+    return acc;
+  }, {});
+};
+
+const layoutForRoom = (
+  room: RoomDefinition,
+  occupants: AvatarRuntimeState[],
+): Record<string, Vector2> => {
+  if (room.boundary.type === 'rect') {
+    return layoutRectangularRoom(room, occupants);
+  }
+  return layoutCircularRoom(room, occupants);
+};
+
+export const computeRoomLayout = (
+  rooms: RoomDefinition[],
+  avatars: Record<string, AvatarRuntimeState>,
+): Record<string, Vector2> => {
+  if (!rooms.length) return {};
+
+  const layout: Record<string, Vector2> = {};
+  const roomById = new Map(rooms.map((room) => [room.id, room] as const));
+
+  const occupantsByRoom = new Map<string, AvatarRuntimeState[]>();
+
+  Object.values(avatars)
+    .sort((a, b) => {
+      if (a.roomId !== b.roomId) return a.roomId.localeCompare(b.roomId);
+      if (a.isLocal === b.isLocal) return a.displayName.localeCompare(b.displayName);
+      return a.isLocal ? -1 : 1;
+    })
+    .forEach((avatar) => {
+      const list = occupantsByRoom.get(avatar.roomId) ?? [];
+      list.push(avatar);
+      occupantsByRoom.set(avatar.roomId, list);
+    });
+
+  occupantsByRoom.forEach((occupants, roomId) => {
+    const room = roomById.get(roomId);
+    if (!room) return;
+    const roomLayout = layoutForRoom(room, occupants);
+    Object.assign(layout, roomLayout);
+  });
+
+  return layout;
+};

--- a/nexspace-frontend/src/features/threeDMode/utils/spatial.ts
+++ b/nexspace-frontend/src/features/threeDMode/utils/spatial.ts
@@ -41,8 +41,19 @@ export const resolveRoomForPosition = (
   return fallbackRoomId;
 };
 
-export const clampToCampusBounds = (position: Vector2, rooms: RoomDefinition[]): Vector2 => {
-  if (!rooms.length) return position;
+export type CampusBounds = {
+  minX: number;
+  maxX: number;
+  minY: number;
+  maxY: number;
+  width: number;
+  height: number;
+};
+
+export const computeCampusBounds = (rooms: RoomDefinition[]): CampusBounds | null => {
+  if (!rooms.length) {
+    return null;
+  }
 
   let minX = Number.POSITIVE_INFINITY;
   let maxX = Number.NEGATIVE_INFINITY;
@@ -66,9 +77,23 @@ export const clampToCampusBounds = (position: Vector2, rooms: RoomDefinition[]):
     }
   });
 
+  return {
+    minX,
+    maxX,
+    minY,
+    maxY,
+    width: maxX - minX,
+    height: maxY - minY,
+  };
+};
+
+export const clampToCampusBounds = (position: Vector2, rooms: RoomDefinition[]): Vector2 => {
+  const bounds = computeCampusBounds(rooms);
+  if (!bounds) return position;
+
   const padding = 4;
   return {
-    x: clamp(position.x, minX - padding, maxX + padding),
-    y: clamp(position.y, minY - padding, maxY + padding),
+    x: clamp(position.x, bounds.minX - padding, bounds.maxX + padding),
+    y: clamp(position.y, bounds.minY - padding, bounds.maxY + padding),
   };
 };

--- a/nexspace-frontend/src/features/threeDMode/utils/spatial.ts
+++ b/nexspace-frontend/src/features/threeDMode/utils/spatial.ts
@@ -1,0 +1,74 @@
+import type { RoomDefinition } from '../config/rooms';
+import type { Vector2 } from '../store/threeDStore';
+
+const clamp = (value: number, min: number, max: number): number => Math.min(Math.max(value, min), max);
+
+export const pointInRect = (point: Vector2, center: [number, number], size: [number, number], rotation = 0): boolean => {
+  const [cx, cy] = center;
+  const [width, height] = size;
+  const translatedX = point.x - cx;
+  const translatedY = point.y - cy;
+
+  const cos = Math.cos(-rotation);
+  const sin = Math.sin(-rotation);
+  const rotatedX = translatedX * cos - translatedY * sin;
+  const rotatedY = translatedX * sin + translatedY * cos;
+
+  return Math.abs(rotatedX) <= width / 2 && Math.abs(rotatedY) <= height / 2;
+};
+
+export const pointInCircle = (point: Vector2, center: [number, number], radius: number): boolean => {
+  const dx = point.x - center[0];
+  const dy = point.y - center[1];
+  return dx * dx + dy * dy <= radius * radius;
+};
+
+export const resolveRoomForPosition = (
+  position: Vector2,
+  rooms: RoomDefinition[],
+  fallbackRoomId: string,
+): string => {
+  for (const room of rooms) {
+    const boundary = room.boundary;
+    if (boundary.type === 'rect' && pointInRect(position, boundary.center, boundary.size, boundary.rotation ?? 0)) {
+      return room.id;
+    }
+    if (boundary.type === 'circle' && pointInCircle(position, boundary.center, boundary.radius)) {
+      return room.id;
+    }
+  }
+
+  return fallbackRoomId;
+};
+
+export const clampToCampusBounds = (position: Vector2, rooms: RoomDefinition[]): Vector2 => {
+  if (!rooms.length) return position;
+
+  let minX = Number.POSITIVE_INFINITY;
+  let maxX = Number.NEGATIVE_INFINITY;
+  let minY = Number.POSITIVE_INFINITY;
+  let maxY = Number.NEGATIVE_INFINITY;
+
+  rooms.forEach((room) => {
+    const boundary = room.boundary;
+    if (boundary.type === 'rect') {
+      const halfW = boundary.size[0] / 2;
+      const halfH = boundary.size[1] / 2;
+      minX = Math.min(minX, boundary.center[0] - halfW);
+      maxX = Math.max(maxX, boundary.center[0] + halfW);
+      minY = Math.min(minY, boundary.center[1] - halfH);
+      maxY = Math.max(maxY, boundary.center[1] + halfH);
+    } else {
+      minX = Math.min(minX, boundary.center[0] - boundary.radius);
+      maxX = Math.max(maxX, boundary.center[0] + boundary.radius);
+      minY = Math.min(minY, boundary.center[1] - boundary.radius);
+      maxY = Math.max(maxY, boundary.center[1] + boundary.radius);
+    }
+  });
+
+  const padding = 4;
+  return {
+    x: clamp(position.x, minX - padding, maxX + padding),
+    y: clamp(position.y, minY - padding, maxY + padding),
+  };
+};

--- a/nexspace-frontend/tsconfig.app.json
+++ b/nexspace-frontend/tsconfig.app.json
@@ -14,7 +14,7 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
-    "types": ["vite/client"] ,
+    "types": ["vite/client"],
 
     /* Linting */
     "strict": true,
@@ -24,5 +24,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/**/__tests__"]
 }

--- a/nexspace-frontend/vitest.config.ts
+++ b/nexspace-frontend/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+    coverage: {
+      reporter: ['text', 'json-summary'],
+      exclude: ['src/main.tsx', 'src/vite-env.d.ts'],
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add a reusable 3D mode feature package with minimap, join-nudge panel, and quality controls
- introduce data-driven room configuration, theme tokens, and persistence for the meeting view mode
- wire the new experience into the meeting panel and add vitest configuration plus join-nudge unit tests

## Testing
- npm -w nexspace-frontend run test -- --run *(fails: vitest dependency blocked by registry policy)*

------
https://chatgpt.com/codex/tasks/task_e_68e6893ce520832695652f2cc8e489c5